### PR TITLE
RemotePi 3.2.2 again

### DIFF
--- a/remotepi/install.sh
+++ b/remotepi/install.sh
@@ -33,4 +33,4 @@ apt-get update || { echo "Running apt-get update failed"; exit 3; }
 apt-get -y install build-essential || { echo "Installing build-essential failed"; exit 3; }
 
 echo "Installing module \"onoff\""
-npm install --prefix "$PLUGIN_DIR" onoff@^6.0.0 || { echo "Installing module \"onoff\" failed"; exit 3; }
+sudo -u volumio npm install --prefix "$PLUGIN_DIR" onoff@^6.0.0 || { echo "Installing module \"onoff\" failed"; exit 3; }

--- a/remotepi/package.json
+++ b/remotepi/package.json
@@ -8,7 +8,7 @@
 	},
 	"author": "gvolt",
 	"license": "ISC",
-	"repository": "https://github.com/volumio/volumio-plugins-sources/tree/master/remotepi",
+	"repository": "https://github.com/volumio/volumio-plugins-sources-bookworm/tree/master/remotepi",
 	"volumio_info": {
 		"prettyName": "RemotePi",
 		"icon": "fa-power-off",


### PR DESCRIPTION
I discovered that uninstalling the (manually installed) RemotePi plugin fails with the error EACCESS: permission denied, unlink '/data/plugins/system_hardware/remotepi/noded_modules/bindings/LICENSE.md'. This PR resolves this issue. Also,  the plugin's repo URL in "package.json" has been adjusted to the bookworm dedicated repo address.

As the plugin is not yet available in the plugin store, I have decided to keep the version number 3.2.2 and just resubmit the plugin. Please let me know if a new version number should be used.