### PR TITLE
IR Controller 3.4.13 again

### DIFF
--- a/ir_controller/package.json
+++ b/ir_controller/package.json
@@ -8,7 +8,7 @@
 	},
 	"author": "Volumio Team, gvolt",
 	"license": "ISC",
-	"repository": "https://github.com/volumio/volumio-plugins-sources/tree/master/ir_controller",
+	"repository": "https://github.com/volumio/volumio-plugins-sources-bookworm/tree/master/ir_controller",
 	"volumio_info": {
 		"prettyName": "IR Remote Controller",
 		"icon": "fa-magic",


### PR DESCRIPTION
Only the plugin's repo URL in "package.json" has been adjusted to the bookworm dedicated repo address.

As the plugin is not yet available in the plugin store, I have decided to keep the version number 3.4.13 and just resubmit the plugin. Please let me know if a new version number should be used.