### PR TITLE
chore(touch_display): update plugin with robust Chromium install and upgrade handling

### DIFF
--- a/touch_display/package.json
+++ b/touch_display/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "touch_display",
-	"version": "3.5.2",
+	"version": "3.5.3",
 	"description": "The plugin enables displaying and operating Volumio's UI on a locally connected screen. NOTE: The plugin cannot be installed on systems that have a factory option to display the UI via HDMI video output.",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
- Replaces chromium install with GitHub-hosted .deb files by architecture
- Checks and enforces specific Chromium version, re-installs if mismatched
- Purges dependent and leftover packages before reinstall (e.g. rpi-chromium-mods, zenoty)
- Ensures Chromium policy file is always overwritten cleanly
- Replaces virtual keyboard clone with clean delete-and-clone flow
- Makes installation idempotent, resilient to prior plugin versions or upgrades
