### PR TITLE
Fsct bump 0.2.12

### DIFF
--- a/ferrum_streaming_control_technology/index.js
+++ b/ferrum_streaming_control_technology/index.js
@@ -125,7 +125,6 @@ FerrumStreamingControlTechnology.prototype.onStop = function () {
             defer.reject(err);
         });
 
-
     return defer.promise;
 };
 

--- a/ferrum_streaming_control_technology/index.js
+++ b/ferrum_streaming_control_technology/index.js
@@ -115,18 +115,18 @@ FerrumStreamingControlTechnology.prototype.onStop = function () {
     var self = this;
     var defer = libQ.defer();
 
-    try {
-        fsctService.stopFsct();
-    }
-    catch (e) {
-        self.logger.error(e);
-    }
+    fsctService.stopFsct()
+        .then(function () {
+            self.logger.info("FSCT Stoped");
+            defer.resolve();
+        })
+        .catch((err) => {
+            self.logger.error(err);
+            defer.reject(err);
+        });
 
-    // Once the Plugin has successfull stopped resolve the promise
-    defer.resolve();
-    self.logger.info('FSCT Stopped');
 
-    return libQ.resolve();
+    return defer.promise;
 };
 
 FerrumStreamingControlTechnology.prototype.onRestart = function () {

--- a/ferrum_streaming_control_technology/package-lock.json
+++ b/ferrum_streaming_control_technology/package-lock.json
@@ -1,15 +1,15 @@
 {
 	"name": "ferrum_streaming_control_technology",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "ferrum_streaming_control_technology",
-			"version": "1.0.1",
+			"version": "1.0.2",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@hemspzoo/fsct-lib": "^0.2.9",
+				"@hemspzoo/fsct-lib": "^0.2.11",
 				"fs-extra": "^0.28.0",
 				"kew": "^0.7.0",
 				"v-conf": "^1.4.0"
@@ -20,22 +20,22 @@
 			}
 		},
 		"node_modules/@hemspzoo/fsct-lib": {
-			"version": "0.2.9",
-			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib/-/fsct-lib-0.2.9.tgz",
-			"integrity": "sha512-mvqSq/LIVtE5hSLnOk0pKSAv81iA7yAyRE9QPLN1AYyFV5ZbvH6xoC7mCAMnVtFt++FG/pudIEKaOg8x9N6wOA==",
+			"version": "0.2.11",
+			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib/-/fsct-lib-0.2.11.tgz",
+			"integrity": "sha512-fZlf09TyeyPMuOgmFjtoThKOTKHV1m0R6nwXx3OWGT/2/RCBMSGdRW2oow/8dKlgDZU2kdxhvA0wChuDZUBPEg==",
 			"engines": {
 				"node": ">= 10"
 			},
 			"optionalDependencies": {
-				"@hemspzoo/fsct-lib-linux-arm-gnueabihf": "0.2.9",
-				"@hemspzoo/fsct-lib-linux-arm64-gnu": "0.2.9",
-				"@hemspzoo/fsct-lib-linux-x64-gnu": "0.2.9"
+				"@hemspzoo/fsct-lib-linux-arm-gnueabihf": "0.2.11",
+				"@hemspzoo/fsct-lib-linux-arm64-gnu": "0.2.11",
+				"@hemspzoo/fsct-lib-linux-x64-gnu": "0.2.11"
 			}
 		},
 		"node_modules/@hemspzoo/fsct-lib-linux-arm-gnueabihf": {
-			"version": "0.2.9",
-			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib-linux-arm-gnueabihf/-/fsct-lib-linux-arm-gnueabihf-0.2.9.tgz",
-			"integrity": "sha512-iaKkI+zoZ1qHtUyjdNSe672tJIkHcQ7hjMNDAzSXUnSN5FG9+vlHgSAHZvzPiM/1Nm+MaqAK3VrHKLETaMPlQg==",
+			"version": "0.2.11",
+			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib-linux-arm-gnueabihf/-/fsct-lib-linux-arm-gnueabihf-0.2.11.tgz",
+			"integrity": "sha512-heTRQVepPm8GfKCxOALlhswfg7SDTOBUt2JFsNuww1M9w7INbMw1aDPeCR42hh98aNZ0zW1cc4D1oOar8Yp0QQ==",
 			"cpu": [
 				"arm"
 			],
@@ -48,9 +48,9 @@
 			}
 		},
 		"node_modules/@hemspzoo/fsct-lib-linux-arm64-gnu": {
-			"version": "0.2.9",
-			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib-linux-arm64-gnu/-/fsct-lib-linux-arm64-gnu-0.2.9.tgz",
-			"integrity": "sha512-gz6TyXtYeWXvJds1P942NpDcK6Zx5uTrYx6x6AGhXVX7U8tVooyEL1XvVgnyEy+Z+LA7mINnBju8TfGUknEZuA==",
+			"version": "0.2.11",
+			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib-linux-arm64-gnu/-/fsct-lib-linux-arm64-gnu-0.2.11.tgz",
+			"integrity": "sha512-SdQl2jGvNkmjzMLQtwt6bxJY8hshkLs1yl6dshjBaECUYLpLxhWOtTj5loo9aYiX3PWVC4JypBEct/lObgyViw==",
 			"cpu": [
 				"arm64"
 			],
@@ -63,9 +63,9 @@
 			}
 		},
 		"node_modules/@hemspzoo/fsct-lib-linux-x64-gnu": {
-			"version": "0.2.9",
-			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib-linux-x64-gnu/-/fsct-lib-linux-x64-gnu-0.2.9.tgz",
-			"integrity": "sha512-NJFkcOgGhKGEjaEc/L+ljpBWotuFKXtgFvD/LHHPAjizgCRMI7SacZUb7DAGaVw42z3wCfQsOmvGu7UCTRH6Sw==",
+			"version": "0.2.11",
+			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib-linux-x64-gnu/-/fsct-lib-linux-x64-gnu-0.2.11.tgz",
+			"integrity": "sha512-S3H3HPm/Njat+/PfqEgrYwgjMsQe9q9qNGOefYvQB7iAYtmYrKgjjwGyrdPGPAEP9SXmN7wzpUDUzTDL3fnd4g==",
 			"cpu": [
 				"x64"
 			],

--- a/ferrum_streaming_control_technology/package-lock.json
+++ b/ferrum_streaming_control_technology/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.0.2",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@hemspzoo/fsct-lib": "^0.2.12-1",
+				"@hemspzoo/fsct-lib": "^0.2.12",
 				"fs-extra": "^0.28.0",
 				"kew": "^0.7.0",
 				"v-conf": "^1.4.0"
@@ -20,22 +20,22 @@
 			}
 		},
 		"node_modules/@hemspzoo/fsct-lib": {
-			"version": "0.2.12-1",
-			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib/-/fsct-lib-0.2.12-1.tgz",
-			"integrity": "sha512-yoKZ+h/70SvaDJpJiOLslw6eCH1jy8X/hAbjyyc/VZeZag3mHx34gxUD2H0nTCdfyP6pLfjI5Z8PYuUwIkvwAQ==",
+			"version": "0.2.12",
+			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib/-/fsct-lib-0.2.12.tgz",
+			"integrity": "sha512-j6MkqLQnu6sjmEexsApjVIISVAkWT6TWBPImELT1vX8uWG9z/gCgh2HE5pmyG47sUU6qiiQYPySctQpmBpMMSw==",
 			"engines": {
 				"node": ">= 10"
 			},
 			"optionalDependencies": {
-				"@hemspzoo/fsct-lib-linux-arm-gnueabihf": "0.2.12-1",
-				"@hemspzoo/fsct-lib-linux-arm64-gnu": "0.2.12-1",
-				"@hemspzoo/fsct-lib-linux-x64-gnu": "0.2.12-1"
+				"@hemspzoo/fsct-lib-linux-arm-gnueabihf": "0.2.12",
+				"@hemspzoo/fsct-lib-linux-arm64-gnu": "0.2.12",
+				"@hemspzoo/fsct-lib-linux-x64-gnu": "0.2.12"
 			}
 		},
 		"node_modules/@hemspzoo/fsct-lib-linux-arm-gnueabihf": {
-			"version": "0.2.12-1",
-			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib-linux-arm-gnueabihf/-/fsct-lib-linux-arm-gnueabihf-0.2.12-1.tgz",
-			"integrity": "sha512-N7Vyi2xJir6xb1+caFPFWPKVlHF3NFi/As5TTafH29u+3P4K7BPA56kH4ATBSGLkrdoWM6zFLdFX/YsbV34Hqw==",
+			"version": "0.2.12",
+			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib-linux-arm-gnueabihf/-/fsct-lib-linux-arm-gnueabihf-0.2.12.tgz",
+			"integrity": "sha512-VRu/dUj52KLk5IHXitXfFQRTrNFv2hsfLgBWHqLMZk//Sy8PVQg1cC6QSnuxucD9RGBvjE1ekEzepfi6OWcqdA==",
 			"cpu": [
 				"arm"
 			],
@@ -48,9 +48,9 @@
 			}
 		},
 		"node_modules/@hemspzoo/fsct-lib-linux-arm64-gnu": {
-			"version": "0.2.12-1",
-			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib-linux-arm64-gnu/-/fsct-lib-linux-arm64-gnu-0.2.12-1.tgz",
-			"integrity": "sha512-+OUksqkZ7nDJJ5wBu6PbOvibxqsaxpu9GIMf9GL+EWpkJMwf7VWu8vetcpae9sclMbRbndMt/r7YLSIxKkRdjw==",
+			"version": "0.2.12",
+			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib-linux-arm64-gnu/-/fsct-lib-linux-arm64-gnu-0.2.12.tgz",
+			"integrity": "sha512-LcI1YaHtjOS/wxbqPrSlrYuR06t1p20jmCJZVWzmhh54dYLNCQ8Rm3IMfoFFpKxUOG5+NoUtpjBm6/xP0oZ3xg==",
 			"cpu": [
 				"arm64"
 			],
@@ -63,9 +63,9 @@
 			}
 		},
 		"node_modules/@hemspzoo/fsct-lib-linux-x64-gnu": {
-			"version": "0.2.12-1",
-			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib-linux-x64-gnu/-/fsct-lib-linux-x64-gnu-0.2.12-1.tgz",
-			"integrity": "sha512-sUbbZ3fnmT5fzigSmZWZ3hKIAHphgDMIBqA7fiqbFZPu979+5dN0Hzl5KBJLZ8qgAHpxZZBSJCOA7zAc2mR/Hw==",
+			"version": "0.2.12",
+			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib-linux-x64-gnu/-/fsct-lib-linux-x64-gnu-0.2.12.tgz",
+			"integrity": "sha512-OLc8CjjPkPGtZmMz9OltG6qUBvR3v//4OUYi8NVgPvhe4FPybBE9qCYLFAZqWaTi+JregnpICSo33D1vEocg5Q==",
 			"cpu": [
 				"x64"
 			],

--- a/ferrum_streaming_control_technology/package-lock.json
+++ b/ferrum_streaming_control_technology/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.0.2",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@hemspzoo/fsct-lib": "^0.2.11",
+				"@hemspzoo/fsct-lib": "^0.2.12-1",
 				"fs-extra": "^0.28.0",
 				"kew": "^0.7.0",
 				"v-conf": "^1.4.0"
@@ -20,22 +20,22 @@
 			}
 		},
 		"node_modules/@hemspzoo/fsct-lib": {
-			"version": "0.2.11",
-			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib/-/fsct-lib-0.2.11.tgz",
-			"integrity": "sha512-fZlf09TyeyPMuOgmFjtoThKOTKHV1m0R6nwXx3OWGT/2/RCBMSGdRW2oow/8dKlgDZU2kdxhvA0wChuDZUBPEg==",
+			"version": "0.2.12-1",
+			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib/-/fsct-lib-0.2.12-1.tgz",
+			"integrity": "sha512-yoKZ+h/70SvaDJpJiOLslw6eCH1jy8X/hAbjyyc/VZeZag3mHx34gxUD2H0nTCdfyP6pLfjI5Z8PYuUwIkvwAQ==",
 			"engines": {
 				"node": ">= 10"
 			},
 			"optionalDependencies": {
-				"@hemspzoo/fsct-lib-linux-arm-gnueabihf": "0.2.11",
-				"@hemspzoo/fsct-lib-linux-arm64-gnu": "0.2.11",
-				"@hemspzoo/fsct-lib-linux-x64-gnu": "0.2.11"
+				"@hemspzoo/fsct-lib-linux-arm-gnueabihf": "0.2.12-1",
+				"@hemspzoo/fsct-lib-linux-arm64-gnu": "0.2.12-1",
+				"@hemspzoo/fsct-lib-linux-x64-gnu": "0.2.12-1"
 			}
 		},
 		"node_modules/@hemspzoo/fsct-lib-linux-arm-gnueabihf": {
-			"version": "0.2.11",
-			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib-linux-arm-gnueabihf/-/fsct-lib-linux-arm-gnueabihf-0.2.11.tgz",
-			"integrity": "sha512-heTRQVepPm8GfKCxOALlhswfg7SDTOBUt2JFsNuww1M9w7INbMw1aDPeCR42hh98aNZ0zW1cc4D1oOar8Yp0QQ==",
+			"version": "0.2.12-1",
+			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib-linux-arm-gnueabihf/-/fsct-lib-linux-arm-gnueabihf-0.2.12-1.tgz",
+			"integrity": "sha512-N7Vyi2xJir6xb1+caFPFWPKVlHF3NFi/As5TTafH29u+3P4K7BPA56kH4ATBSGLkrdoWM6zFLdFX/YsbV34Hqw==",
 			"cpu": [
 				"arm"
 			],
@@ -48,9 +48,9 @@
 			}
 		},
 		"node_modules/@hemspzoo/fsct-lib-linux-arm64-gnu": {
-			"version": "0.2.11",
-			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib-linux-arm64-gnu/-/fsct-lib-linux-arm64-gnu-0.2.11.tgz",
-			"integrity": "sha512-SdQl2jGvNkmjzMLQtwt6bxJY8hshkLs1yl6dshjBaECUYLpLxhWOtTj5loo9aYiX3PWVC4JypBEct/lObgyViw==",
+			"version": "0.2.12-1",
+			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib-linux-arm64-gnu/-/fsct-lib-linux-arm64-gnu-0.2.12-1.tgz",
+			"integrity": "sha512-+OUksqkZ7nDJJ5wBu6PbOvibxqsaxpu9GIMf9GL+EWpkJMwf7VWu8vetcpae9sclMbRbndMt/r7YLSIxKkRdjw==",
 			"cpu": [
 				"arm64"
 			],
@@ -63,9 +63,9 @@
 			}
 		},
 		"node_modules/@hemspzoo/fsct-lib-linux-x64-gnu": {
-			"version": "0.2.11",
-			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib-linux-x64-gnu/-/fsct-lib-linux-x64-gnu-0.2.11.tgz",
-			"integrity": "sha512-S3H3HPm/Njat+/PfqEgrYwgjMsQe9q9qNGOefYvQB7iAYtmYrKgjjwGyrdPGPAEP9SXmN7wzpUDUzTDL3fnd4g==",
+			"version": "0.2.12-1",
+			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib-linux-x64-gnu/-/fsct-lib-linux-x64-gnu-0.2.12-1.tgz",
+			"integrity": "sha512-sUbbZ3fnmT5fzigSmZWZ3hKIAHphgDMIBqA7fiqbFZPu979+5dN0Hzl5KBJLZ8qgAHpxZZBSJCOA7zAc2mR/Hw==",
 			"cpu": [
 				"x64"
 			],

--- a/ferrum_streaming_control_technology/package.json
+++ b/ferrum_streaming_control_technology/package.json
@@ -38,6 +38,6 @@
 		"fs-extra": "^0.28.0",
 		"kew": "^0.7.0",
 		"v-conf": "^1.4.0",
-		"@hemspzoo/fsct-lib": "^0.2.12-1"
+		"@hemspzoo/fsct-lib": "^0.2.12"
 	}
 }

--- a/ferrum_streaming_control_technology/package.json
+++ b/ferrum_streaming_control_technology/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ferrum_streaming_control_technology",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "Plugin provides support for Ferrum Streaming Control Technology™ allowing DACs (e.g. Ferrum Wandla) to show current state of playback like title, artist and progress bar.",
 	"main": "index.js",
 	"scripts": {
@@ -28,7 +28,7 @@
 			"bookworm"
 		],
 		"details": "Plugin provides support for Ferrum Streaming Control Technology™ allowing DACs (e.g. Ferrum Wandla) to show current state of playback like title, artist and progress bar.",
-		"changelog": " * 1.0.0 - first published ™version"
+		"changelog": " * 1.0.2 - plugin with fsct-lib bumped to 0.2.11, version which supporst first official FSCT release."
 	},
 	"engines": {
 		"node": ">=20",
@@ -38,6 +38,6 @@
 		"fs-extra": "^0.28.0",
 		"kew": "^0.7.0",
 		"v-conf": "^1.4.0",
-		"@hemspzoo/fsct-lib": "^0.2.9"
+		"@hemspzoo/fsct-lib": "^0.2.11"
 	}
 }

--- a/ferrum_streaming_control_technology/package.json
+++ b/ferrum_streaming_control_technology/package.json
@@ -28,7 +28,7 @@
 			"bookworm"
 		],
 		"details": "Plugin provides support for Ferrum Streaming Control Technology™ allowing DACs (e.g. Ferrum Wandla) to show current state of playback like title, artist and progress bar.",
-		"changelog": " * 1.0.2 - plugin with fsct-lib bumped to 0.2.11, version which supporst first official FSCT release."
+		"changelog": " * 1.0.2 - plugin with fsct-lib bumped to 0.2.12, version which supports first official FSCT release."
 	},
 	"engines": {
 		"node": ">=20",
@@ -38,6 +38,6 @@
 		"fs-extra": "^0.28.0",
 		"kew": "^0.7.0",
 		"v-conf": "^1.4.0",
-		"@hemspzoo/fsct-lib": "^0.2.11"
+		"@hemspzoo/fsct-lib": "^0.2.12-1"
 	}
 }


### PR DESCRIPTION
Hi,

I've bumped version of our library to latest version. It has improved stopping and restarting the whole our service internally, and removed polling, which was there in the previous version. There are rather minor changes to previous release.

I've also created PR for buster version.