### PR TITLE
Touch Display 3.5.5

### DIFF
--- a/touch_display/install.sh
+++ b/touch_display/install.sh
@@ -86,8 +86,11 @@ else
   dpkg --purge chromium chromium-common chromium-l10n || true
 
   echo "Removing leftover or conflicting Chromium-related packages if present"
+  # Prevent deletion of possibly empty /opt directory by dpkg --purge ... libwidevinecdm0
+  touch /opt/do_not_delete
   # These packages are sometimes left behind and can cause conflicts
   dpkg --purge chromium-codecs-ffmpeg-extra libwidevinecdm0 zenoty || true
+  rm /opt/do_not_delete
 
   GITHUB_BASE_URL="https://github.com/volumio/volumio3-os-static-assets/raw/master/browsers/chromium"
   TMP_DEB_DIR="/tmp/volumio-chromium"

--- a/touch_display/package.json
+++ b/touch_display/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "touch_display",
-	"version": "3.5.4",
+	"version": "3.5.5",
 	"description": "The plugin enables displaying and operating Volumio's UI on a locally connected screen. NOTE: The plugin cannot be installed on systems that have a factory option to display the UI via HDMI video output.",
 	"main": "index.js",
 	"scripts": {
@@ -20,7 +20,7 @@
 			"bookworm"
 		],
 		"details": "The plugin enables the display of Volumio's UI on locally connected screens. If the screen offers touch control, apart from keyboard input the UI can be operated from the screen.<br><br>The plugin focuses on the Raspberry Pi Foundation's 7\" display (and compatible DSI displays), but can in principle also be used with displays connected via HDMI or GPIO. However, HDMI and GPIO displays usually require additional action by the user, depending on the type of display and any touch controller present, and <b>requiring advanced knowledge</b>.<br><br><b>NOTE: The plugin cannot be installed on systems that have a factory option to display the UI via HDMI video output.</b>",
-		"changelog": "Enforce specific chromium version still allowing to use virtual keyboard extension"
+		"changelog": "Prevent /opt to be possibly deleted; corrections for uninstalling packages"
 	},
 	"engines": {
 		"node": ">=20",

--- a/touch_display/uninstall.sh
+++ b/touch_display/uninstall.sh
@@ -8,9 +8,21 @@ apt-get -y purge --auto-remove fonts-ipafont
 apt-get -y purge --auto-remove fonts-vlgothic
 apt-get -y purge --auto-remove fonts-thai-tlwg-ttf
 
-apt-get -y purge --auto-remove chromium
-apt-get -y purge --auto-remove chromium-common
+# apt-get -y purge --auto-remove chromium
+# apt-get -y purge --auto-remove chromium-common
+dpkg --purge rpi-chromium-mods
+dpkg --purge chromium-browser
+dpkg --purge chromium
+dpkg --purge chromium-common
+dpkg --purge chromium-l10n
+dpkg --purge chromium-codecs-ffmpeg-extra
+# Prevent deletion of possibly empty /opt directory by dpkg --purge libwidevinecdm0
+touch /opt/do_not_delete
+dpkg --purge libwidevinecdm0
+rm /opt/do_not_delete
+dpkg --purge zenoty
 rm /usr/bin/chromium-browser
+
 apt-get -y purge --auto-remove openbox
 apt-get -y purge --auto-remove xinit
 apt-get -y purge --auto-remove x11-utils


### PR DESCRIPTION
- "install.sh": Running `dpkg --purge libwidevinecdm0 ` could possibly delete the “/opt” directory if it is empty. To prevent this, an empty file “do_not_delete” is created in “/opt” just before `dpkg --purge chromium-codecs-ffmpeg-extra libwidevinecdm0 zenoty || true` is executed and then removed again.
- "uninstall.sh": Changed to/added `dpkg --purge` commands for packages that are now installed via “dpkg”.