### PR TITLE
Fsct bump 0.2.13

### DIFF
--- a/ferrum_streaming_control_technology/package-lock.json
+++ b/ferrum_streaming_control_technology/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.0.3",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@hemspzoo/fsct-lib": "^0.2.13-rc.1",
+				"@hemspzoo/fsct-lib": "^0.2.13",
 				"fs-extra": "^0.28.0",
 				"kew": "^0.7.0",
 				"v-conf": "^1.4.0"
@@ -20,22 +20,22 @@
 			}
 		},
 		"node_modules/@hemspzoo/fsct-lib": {
-			"version": "0.2.13-rc.1",
-			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib/-/fsct-lib-0.2.13-rc.1.tgz",
-			"integrity": "sha512-7fMRr8/jLqcdqXqXqjqUg+UvVidO0CCkcRe9JFmd4Ayh++WmHw4ZStV+7XVEUgiYc63CH49sueUZVrPUKRoQhw==",
+			"version": "0.2.13",
+			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib/-/fsct-lib-0.2.13.tgz",
+			"integrity": "sha512-S1H4gGp6iWCQb5NXT7egreOmpApX7bQmW+c9pSUz7XVWUNcrOEnhsihVQ4t+YaQ2rTEQx+RkzKYk5F8E3EdDNA==",
 			"engines": {
 				"node": ">= 10"
 			},
 			"optionalDependencies": {
-				"@hemspzoo/fsct-lib-linux-arm-gnueabihf": "0.2.13-rc.1",
-				"@hemspzoo/fsct-lib-linux-arm64-gnu": "0.2.13-rc.1",
-				"@hemspzoo/fsct-lib-linux-x64-gnu": "0.2.13-rc.1"
+				"@hemspzoo/fsct-lib-linux-arm-gnueabihf": "0.2.13",
+				"@hemspzoo/fsct-lib-linux-arm64-gnu": "0.2.13",
+				"@hemspzoo/fsct-lib-linux-x64-gnu": "0.2.13"
 			}
 		},
 		"node_modules/@hemspzoo/fsct-lib-linux-arm-gnueabihf": {
-			"version": "0.2.13-rc.1",
-			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib-linux-arm-gnueabihf/-/fsct-lib-linux-arm-gnueabihf-0.2.13-rc.1.tgz",
-			"integrity": "sha512-YATmGmd7z9SUd7lAOkYVMoylNy+KVUdW/V7ft8uvlw2rHmQkNSbLBxJT9mlioNNAMaJrs7L1g5ahm/mIRTztbQ==",
+			"version": "0.2.13",
+			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib-linux-arm-gnueabihf/-/fsct-lib-linux-arm-gnueabihf-0.2.13.tgz",
+			"integrity": "sha512-VXpRrFeut3cR6dhU6X2roD5bBm5UlNJH4mnHOcUMS1Fc7ISvsaOGQRcbFQEAtWYTytDtF6Z4jOJWM56CGGCaWg==",
 			"cpu": [
 				"arm"
 			],
@@ -48,9 +48,9 @@
 			}
 		},
 		"node_modules/@hemspzoo/fsct-lib-linux-arm64-gnu": {
-			"version": "0.2.13-rc.1",
-			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib-linux-arm64-gnu/-/fsct-lib-linux-arm64-gnu-0.2.13-rc.1.tgz",
-			"integrity": "sha512-/Vnp5VgHCL6kY8ZKk/iXGIND8SscqOctuJAMNNh8FzYaWw0+Z2ejn+ySy2QwS+5IucyPegG35d5fi6DbUzvgjg==",
+			"version": "0.2.13",
+			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib-linux-arm64-gnu/-/fsct-lib-linux-arm64-gnu-0.2.13.tgz",
+			"integrity": "sha512-kYzL1VbZi3p8sSVsv45F1t3RPGFWgzio1KtGn/z8eTxY3W0BiuLCq27vRpQP69KOKV8HeOdeNzr550MOCMAJMQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -63,9 +63,9 @@
 			}
 		},
 		"node_modules/@hemspzoo/fsct-lib-linux-x64-gnu": {
-			"version": "0.2.13-rc.1",
-			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib-linux-x64-gnu/-/fsct-lib-linux-x64-gnu-0.2.13-rc.1.tgz",
-			"integrity": "sha512-I5X1GLtCmX8aa2zhnJNCWsdKl3mSkGKqkJKaggvvY3cmHbHzA9yXn0qkj01Mkvy5GlX8wCwngcYQmzviiO1Zvg==",
+			"version": "0.2.13",
+			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib-linux-x64-gnu/-/fsct-lib-linux-x64-gnu-0.2.13.tgz",
+			"integrity": "sha512-6MD/josF0tFGkvtl/WZOXFQdrOxCxfyl/hdQfXFRxURUdm+et5278MbIGAyystRqCDllrso98RchGBULrho1iQ==",
 			"cpu": [
 				"x64"
 			],

--- a/ferrum_streaming_control_technology/package-lock.json
+++ b/ferrum_streaming_control_technology/package-lock.json
@@ -1,41 +1,41 @@
 {
 	"name": "ferrum_streaming_control_technology",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "ferrum_streaming_control_technology",
-			"version": "1.0.2",
+			"version": "1.0.3",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@hemspzoo/fsct-lib": "^0.2.12",
+				"@hemspzoo/fsct-lib": "^0.2.13-rc.1",
 				"fs-extra": "^0.28.0",
 				"kew": "^0.7.0",
 				"v-conf": "^1.4.0"
 			},
 			"engines": {
 				"node": ">=20",
-				"volumio": ">=0"
+				"volumio": ">=4"
 			}
 		},
 		"node_modules/@hemspzoo/fsct-lib": {
-			"version": "0.2.12",
-			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib/-/fsct-lib-0.2.12.tgz",
-			"integrity": "sha512-j6MkqLQnu6sjmEexsApjVIISVAkWT6TWBPImELT1vX8uWG9z/gCgh2HE5pmyG47sUU6qiiQYPySctQpmBpMMSw==",
+			"version": "0.2.13-rc.1",
+			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib/-/fsct-lib-0.2.13-rc.1.tgz",
+			"integrity": "sha512-7fMRr8/jLqcdqXqXqjqUg+UvVidO0CCkcRe9JFmd4Ayh++WmHw4ZStV+7XVEUgiYc63CH49sueUZVrPUKRoQhw==",
 			"engines": {
 				"node": ">= 10"
 			},
 			"optionalDependencies": {
-				"@hemspzoo/fsct-lib-linux-arm-gnueabihf": "0.2.12",
-				"@hemspzoo/fsct-lib-linux-arm64-gnu": "0.2.12",
-				"@hemspzoo/fsct-lib-linux-x64-gnu": "0.2.12"
+				"@hemspzoo/fsct-lib-linux-arm-gnueabihf": "0.2.13-rc.1",
+				"@hemspzoo/fsct-lib-linux-arm64-gnu": "0.2.13-rc.1",
+				"@hemspzoo/fsct-lib-linux-x64-gnu": "0.2.13-rc.1"
 			}
 		},
 		"node_modules/@hemspzoo/fsct-lib-linux-arm-gnueabihf": {
-			"version": "0.2.12",
-			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib-linux-arm-gnueabihf/-/fsct-lib-linux-arm-gnueabihf-0.2.12.tgz",
-			"integrity": "sha512-VRu/dUj52KLk5IHXitXfFQRTrNFv2hsfLgBWHqLMZk//Sy8PVQg1cC6QSnuxucD9RGBvjE1ekEzepfi6OWcqdA==",
+			"version": "0.2.13-rc.1",
+			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib-linux-arm-gnueabihf/-/fsct-lib-linux-arm-gnueabihf-0.2.13-rc.1.tgz",
+			"integrity": "sha512-YATmGmd7z9SUd7lAOkYVMoylNy+KVUdW/V7ft8uvlw2rHmQkNSbLBxJT9mlioNNAMaJrs7L1g5ahm/mIRTztbQ==",
 			"cpu": [
 				"arm"
 			],
@@ -48,9 +48,9 @@
 			}
 		},
 		"node_modules/@hemspzoo/fsct-lib-linux-arm64-gnu": {
-			"version": "0.2.12",
-			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib-linux-arm64-gnu/-/fsct-lib-linux-arm64-gnu-0.2.12.tgz",
-			"integrity": "sha512-LcI1YaHtjOS/wxbqPrSlrYuR06t1p20jmCJZVWzmhh54dYLNCQ8Rm3IMfoFFpKxUOG5+NoUtpjBm6/xP0oZ3xg==",
+			"version": "0.2.13-rc.1",
+			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib-linux-arm64-gnu/-/fsct-lib-linux-arm64-gnu-0.2.13-rc.1.tgz",
+			"integrity": "sha512-/Vnp5VgHCL6kY8ZKk/iXGIND8SscqOctuJAMNNh8FzYaWw0+Z2ejn+ySy2QwS+5IucyPegG35d5fi6DbUzvgjg==",
 			"cpu": [
 				"arm64"
 			],
@@ -63,9 +63,9 @@
 			}
 		},
 		"node_modules/@hemspzoo/fsct-lib-linux-x64-gnu": {
-			"version": "0.2.12",
-			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib-linux-x64-gnu/-/fsct-lib-linux-x64-gnu-0.2.12.tgz",
-			"integrity": "sha512-OLc8CjjPkPGtZmMz9OltG6qUBvR3v//4OUYi8NVgPvhe4FPybBE9qCYLFAZqWaTi+JregnpICSo33D1vEocg5Q==",
+			"version": "0.2.13-rc.1",
+			"resolved": "https://registry.npmjs.org/@hemspzoo/fsct-lib-linux-x64-gnu/-/fsct-lib-linux-x64-gnu-0.2.13-rc.1.tgz",
+			"integrity": "sha512-I5X1GLtCmX8aa2zhnJNCWsdKl3mSkGKqkJKaggvvY3cmHbHzA9yXn0qkj01Mkvy5GlX8wCwngcYQmzviiO1Zvg==",
 			"cpu": [
 				"x64"
 			],

--- a/ferrum_streaming_control_technology/package.json
+++ b/ferrum_streaming_control_technology/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ferrum_streaming_control_technology",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"description": "Plugin provides support for Ferrum Streaming Control Technology™ allowing DACs (e.g. Ferrum Wandla) to show current state of playback like title, artist and progress bar.",
 	"main": "index.js",
 	"scripts": {
@@ -32,12 +32,12 @@
 	},
 	"engines": {
 		"node": ">=20",
-		"volumio": ">=0"
+		"volumio": ">=4"
 	},
 	"dependencies": {
 		"fs-extra": "^0.28.0",
 		"kew": "^0.7.0",
 		"v-conf": "^1.4.0",
-		"@hemspzoo/fsct-lib": "^0.2.12"
+		"@hemspzoo/fsct-lib": "^0.2.13-rc.1"
 	}
 }

--- a/ferrum_streaming_control_technology/package.json
+++ b/ferrum_streaming_control_technology/package.json
@@ -38,6 +38,6 @@
 		"fs-extra": "^0.28.0",
 		"kew": "^0.7.0",
 		"v-conf": "^1.4.0",
-		"@hemspzoo/fsct-lib": "^0.2.13-rc.1"
+		"@hemspzoo/fsct-lib": "^0.2.13"
 	}
 }


### PR DESCRIPTION
HI, 

This is only a small library bump. The last library contains the fix for BOS descriptor handling. Volumio version has been also updated to >=4 as requested.