### PR TITLE
volumio-stream-watchdog - 1.0.0 initial submission

### DIFF
--- a/volumio-stream-watchdog/README.md
+++ b/volumio-stream-watchdog/README.md
@@ -65,7 +65,7 @@ Navigate to **Plugins → Miscellanea** and search for "Stream Watchdog".
 ssh volumio@volumio.local
 
 # Clone the repo into the plugins directory
-cd /data/plugins/miscellanea
+cd /data/plugins/system_controller
 git clone https://github.com/josemathias/volumio-stream-watchdog volumio-stream-watchdog
 
 # Install dependencies

--- a/volumio-stream-watchdog/README.md
+++ b/volumio-stream-watchdog/README.md
@@ -1,0 +1,126 @@
+# volumio-stream-watchdog
+
+A Volumio 4 plugin that detects genuine streaming failure — not just network loss — and automatically switches to a curated local playlist. When your stream comes back, the plugin resumes it automatically.
+
+## How it works
+
+Most "offline fallback" approaches probe a generic host like `8.8.8.8` via TCP. That misses a large class of real failures: your router is up, DNS works fine, but the radio station server is down or your ISP is dropping streaming traffic selectively. The correct signal is Volumio's own player state.
+
+This plugin uses two detection layers that must both agree before any action is taken:
+
+**Layer 1 — State Watcher (reactive):** Subscribes to Volumio's internal `pushState` socket.io events. When the player was streaming (`stream: true`) and transitions to `stop` without a user-initiated command, it marks a candidate failure.
+
+**Layer 2 — Stream Probe (proactive):** On a configurable interval, makes an HTTP HEAD request directly to the stream URL. Only when both layers confirm failure does the plugin act.
+
+This combination eliminates false positives from brief network hiccups, user-initiated stops, and library scans.
+
+### State machine
+
+```
+IDLE ──► WATCHING ──► SUSPECT ──► FALLBACK
+           ▲                          │
+           └──────────────────────────┘
+                  (stream restored)
+```
+
+- **IDLE** — No stream playing. Plugin is dormant.
+- **WATCHING** — Stream is active. Probes run on `streamCheckInterval`.
+- **SUSPECT** — Unexpected stop detected or first probe failure. Waits one more cycle.
+- **FALLBACK** — Failure confirmed. Local playlist plays. Restoration probes run on `restoreCheckInterval`.
+
+### What happens on failure
+
+1. Current stream URI and queue are snapshotted
+2. A warning toast appears: *"Stream lost — switching to local music."*
+3. Volumio stops and clears the queue
+4. A Volumio playlist named `"Offline"` (configurable) starts playing
+5. If no such playlist exists, the plugin scans `music-library/INTERNAL` as a fallback
+
+### What happens on restore
+
+1. Restoration probe succeeds twice in a row
+2. A success toast appears: *"Stream restored — resuming."*
+3. The original stream resumes automatically (if auto-restore is enabled)
+
+## Requirements
+
+- Volumio 4.x
+- A Volumio playlist named `"Offline"` containing local tracks (create it in Browse → Playlists before any failure occurs)
+- Local music files on the SD card under `music-library/INTERNAL`
+
+## Creating your Offline playlist
+
+In the Volumio UI, browse to your local music, add tracks to the queue, then save the queue as a playlist named **Offline** (or whatever name you configure in settings). That playlist will play automatically whenever your stream fails.
+
+## Installation
+
+### From the Volumio Plugin Store (once published)
+
+Navigate to **Plugins → Miscellanea** and search for "Stream Watchdog".
+
+### Manual install (development)
+
+```bash
+# SSH into your Volumio device
+ssh volumio@volumio.local
+
+# Clone the repo into the plugins directory
+cd /data/plugins/miscellanea
+git clone https://github.com/josemathias/volumio-stream-watchdog volumio-stream-watchdog
+
+# Install dependencies
+cd volumio-stream-watchdog
+npm install
+
+# Restart Volumio
+sudo systemctl restart volumio
+```
+
+Then navigate to **Plugins → Installed Plugins** and enable **Stream Watchdog**.
+
+## Configuration
+
+Open the plugin settings page in Volumio (**Plugins → Installed → Stream Watchdog → Settings**):
+
+| Setting | Default | Description |
+|---|---|---|
+| Offline Playlist Name | `Offline` | Name of the Volumio playlist to play when stream fails |
+| Stream Check Interval (seconds) | `30` | How often to probe the stream URL while watching (minimum: 15) |
+| Restore Check Interval (seconds) | `60` | How often to probe while in fallback mode (minimum: 30) |
+| Auto-Restore | `on` | Automatically resume the original stream when it returns |
+
+## Logs
+
+Plugin activity is written to the Volumio system log. To watch it live:
+
+```bash
+sudo journalctl -fu volumio | grep StreamWatchdog
+```
+
+## Architecture notes
+
+- No external npm dependencies — `http`/`https` probing uses Node.js built-ins
+- `socket.io-client` is referenced from Volumio's own `node_modules` to avoid version conflicts
+- The plugin does not write to `/volumio` or `/myvolumio`
+- All timers and socket connections are cleanly torn down on `onStop`
+
+## Development
+
+Full implementation plan, state machine design, marketplace submission checklist, and phased implementation guide are in [`docs/development-plan.md`](docs/development-plan.md).
+
+### Tests
+
+The test suite uses Node's built-in runner (`node:test`) — no test dependencies to install.
+
+```bash
+npm install        # installs kew + v-conf
+npm run test:l0    # unit tests (state machine, config)
+npm run test:l1    # integration tests (HTTP stream probe)
+npm test           # both
+```
+
+CI runs on GitHub Actions via the QA Lab platform — see `docs/development-plan.md` §8.5.
+
+## License
+
+MIT © josemathias

--- a/volumio-stream-watchdog/UIConfig.json
+++ b/volumio-stream-watchdog/UIConfig.json
@@ -1,0 +1,69 @@
+{
+  "page": {
+    "label": "TRANSLATE.STREAM_WATCHDOG.SETTINGS_LABEL"
+  },
+  "sections": [
+    {
+      "id": "section_settings",
+      "element": "section",
+      "label": "TRANSLATE.STREAM_WATCHDOG.SECTION_SETTINGS",
+      "icon": "fa-wifi",
+      "onSave": {
+        "type": "controller",
+        "endpoint": "miscellanea/volumio-stream-watchdog",
+        "method": "savePluginConfig"
+      },
+      "saveButton": {
+        "label": "TRANSLATE.STREAM_WATCHDOG.SAVE",
+        "data": [
+          "offlinePlaylistName",
+          "streamCheckInterval",
+          "restoreCheckInterval",
+          "autoRestore"
+        ]
+      },
+      "content": [
+        {
+          "id": "offlinePlaylistName",
+          "element": "input",
+          "doc": "",
+          "label": "TRANSLATE.STREAM_WATCHDOG.OFFLINE_PLAYLIST_NAME",
+          "description": "TRANSLATE.STREAM_WATCHDOG.OFFLINE_PLAYLIST_NAME_DESC",
+          "placeholder": "Offline",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "id": "streamCheckInterval",
+          "element": "input",
+          "doc": "",
+          "label": "TRANSLATE.STREAM_WATCHDOG.STREAM_CHECK_INTERVAL",
+          "description": "TRANSLATE.STREAM_WATCHDOG.STREAM_CHECK_INTERVAL_DESC",
+          "placeholder": "30",
+          "type": {
+            "name": "number"
+          }
+        },
+        {
+          "id": "restoreCheckInterval",
+          "element": "input",
+          "doc": "",
+          "label": "TRANSLATE.STREAM_WATCHDOG.RESTORE_CHECK_INTERVAL",
+          "description": "TRANSLATE.STREAM_WATCHDOG.RESTORE_CHECK_INTERVAL_DESC",
+          "placeholder": "60",
+          "type": {
+            "name": "number"
+          }
+        },
+        {
+          "id": "autoRestore",
+          "element": "switch",
+          "doc": "",
+          "label": "TRANSLATE.STREAM_WATCHDOG.AUTO_RESTORE",
+          "description": "TRANSLATE.STREAM_WATCHDOG.AUTO_RESTORE_DESC"
+        }
+      ]
+    }
+  ]
+}

--- a/volumio-stream-watchdog/UIConfig.json
+++ b/volumio-stream-watchdog/UIConfig.json
@@ -10,7 +10,7 @@
       "icon": "fa-wifi",
       "onSave": {
         "type": "controller",
-        "endpoint": "miscellanea/volumio-stream-watchdog",
+        "endpoint": "system_controller/volumio-stream-watchdog",
         "method": "savePluginConfig"
       },
       "saveButton": {

--- a/volumio-stream-watchdog/config.json
+++ b/volumio-stream-watchdog/config.json
@@ -1,0 +1,18 @@
+{
+  "offlinePlaylistName": {
+    "type": "string",
+    "value": "Offline"
+  },
+  "streamCheckInterval": {
+    "type": "number",
+    "value": 30
+  },
+  "restoreCheckInterval": {
+    "type": "number",
+    "value": 60
+  },
+  "autoRestore": {
+    "type": "boolean",
+    "value": true
+  }
+}

--- a/volumio-stream-watchdog/i18n/strings.json
+++ b/volumio-stream-watchdog/i18n/strings.json
@@ -1,0 +1,15 @@
+{
+  "STREAM_WATCHDOG": {
+    "SETTINGS_LABEL": "Stream Watchdog Settings",
+    "SECTION_SETTINGS": "Settings",
+    "OFFLINE_PLAYLIST_NAME": "Offline Playlist Name",
+    "OFFLINE_PLAYLIST_NAME_DESC": "Name of the Volumio playlist to play when your stream fails. Create it in Browse → Playlists before any failure occurs.",
+    "STREAM_CHECK_INTERVAL": "Stream Check Interval (seconds)",
+    "STREAM_CHECK_INTERVAL_DESC": "How often to probe the stream URL while watching. Minimum: 15",
+    "RESTORE_CHECK_INTERVAL": "Restore Check Interval (seconds)",
+    "RESTORE_CHECK_INTERVAL_DESC": "How often to probe the stream URL while in fallback mode. Minimum: 30",
+    "AUTO_RESTORE": "Auto-Restore",
+    "AUTO_RESTORE_DESC": "Automatically resume the original stream when it comes back",
+    "SAVE": "Save Settings"
+  }
+}

--- a/volumio-stream-watchdog/i18n/strings_en.json
+++ b/volumio-stream-watchdog/i18n/strings_en.json
@@ -1,0 +1,15 @@
+{
+  "STREAM_WATCHDOG": {
+    "SETTINGS_LABEL": "Stream Watchdog Settings",
+    "SECTION_SETTINGS": "Settings",
+    "OFFLINE_PLAYLIST_NAME": "Offline Playlist Name",
+    "OFFLINE_PLAYLIST_NAME_DESC": "Name of the Volumio playlist to play when your stream fails. Create it in Browse → Playlists before any failure occurs.",
+    "STREAM_CHECK_INTERVAL": "Stream Check Interval (seconds)",
+    "STREAM_CHECK_INTERVAL_DESC": "How often to probe the stream URL while watching. Minimum: 15",
+    "RESTORE_CHECK_INTERVAL": "Restore Check Interval (seconds)",
+    "RESTORE_CHECK_INTERVAL_DESC": "How often to probe the stream URL while in fallback mode. Minimum: 30",
+    "AUTO_RESTORE": "Auto-Restore",
+    "AUTO_RESTORE_DESC": "Automatically resume the original stream when it comes back",
+    "SAVE": "Save Settings"
+  }
+}

--- a/volumio-stream-watchdog/index.js
+++ b/volumio-stream-watchdog/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // =============================================================================
-// Stream Watchdog — Volumio 4 miscellanea plugin
+// Stream Watchdog — Volumio 4 system_controller plugin
 //
 // Phase 1: Internal socket.io state watcher.
 //   - Connects to Volumio's socket.io interface at localhost:3000

--- a/volumio-stream-watchdog/index.js
+++ b/volumio-stream-watchdog/index.js
@@ -1,0 +1,1127 @@
+'use strict';
+
+// =============================================================================
+// Stream Watchdog — Volumio 4 miscellanea plugin
+//
+// Phase 1: Internal socket.io state watcher.
+//   - Connects to Volumio's socket.io interface at localhost:3000
+//   - Listens to `pushState` and runs the IDLE / WATCHING / SUSPECT transitions
+//   - No probing and no fallback playback yet (Phases 2–5)
+//
+// See docs/development-plan.md for the full design.
+// =============================================================================
+
+// kew and v-conf are core Volumio modules. Reference them from Volumio's own
+// node_modules so a plain `git clone` works without `npm install` — same
+// rationale as socket.io-client (see CLAUDE.md). Fall back to a locally
+// installed copy if the absolute path is unavailable.
+function volumioRequire(name) {
+  try {
+    return require('/volumio/node_modules/' + name);
+  } catch (e) {
+    return require(name);
+  }
+}
+
+var libQ  = volumioRequire('kew');
+var vconf = volumioRequire('v-conf');
+
+module.exports = StreamWatchdog;
+
+// --- Constants ---------------------------------------------------------------
+
+var LOG = '[StreamWatchdog] ';
+
+// MPD and the network take time to settle after boot. Do nothing until this
+// delay has elapsed after onStart — see CLAUDE.md (STARTUP_DELAY).
+var STARTUP_DELAY_MS = 30 * 1000;
+
+// Volumio's internal socket.io endpoint.
+var SOCKET_URL = 'http://localhost:3000';
+
+// Layer 2 — HTTP stream probe (see docs/development-plan.md §3.3).
+var PROBE_TIMEOUT_MS    = 5000; // per-probe HTTP timeout
+var MIN_STREAM_INTERVAL = 15;   // floor for streamCheckInterval, seconds
+
+// Phase 3 — confirmation thresholds (see docs/development-plan.md §3.2).
+var FAIL_THRESHOLD      = 2;    // probe failures required to confirm a failure
+var USER_STOP_WINDOW_MS = 2000; // a stop within this window of volumioStop() is the user's
+
+// Phase 4 — fallback playback (see docs/development-plan.md §4).
+var FALLBACK_STEP_MS  = 500;                   // gap between fire-and-forget playback commands
+var LOCAL_LIBRARY_URI = 'music-library/INTERNAL'; // browsed when no Offline playlist exists
+
+// MPD browse-item types that represent a browseable directory (see the
+// Volumio mpd plugin's lsInfo — folders inside INTERNAL are 'internal-folder').
+var FOLDER_TYPES = ['folder', 'internal-folder', 'remdisk', 'album', 'artist'];
+
+// Phase 5 — auto-restore (see docs/development-plan.md §5).
+var RESTORE_CONFIRM_MS   = 5000; // gap before the confirming restore probe
+var MIN_RESTORE_INTERVAL = 30;   // floor for restoreCheckInterval, seconds
+
+// State machine — see docs/development-plan.md §2.2
+var STATE = {
+  IDLE:     'IDLE',     // no stream active, plugin dormant
+  WATCHING: 'WATCHING', // stream playing, monitored
+  SUSPECT:  'SUSPECT',  // one failure signal received, awaiting confirmation
+  FALLBACK: 'FALLBACK'  // confirmed failure (Phase 4+)
+};
+
+// =============================================================================
+// Constructor
+// =============================================================================
+function StreamWatchdog(context) {
+  var self = this;
+
+  self.context       = context;
+  self.commandRouter = context.coreCommand;
+  self.logger        = context.logger;
+  self.configManager = context.configManager;
+
+  // Runtime state
+  self.state          = STATE.IDLE;
+  self.streamUri      = null;  // URI of the stream currently being watched
+  self.socket         = null;  // socket.io connection to Volumio
+  self.startupTimer   = null;  // STARTUP_DELAY timer handle
+  self.ready          = false; // false until STARTUP_DELAY has elapsed
+  self.probeTimer     = null;  // Layer 2 probe interval handle
+  self.probeFailCount = 0;     // consecutive probe failures
+  self.lastStateSig   = null;  // dedup signature for verbose pushState logging
+  self.userStopFlag   = false; // true briefly after the user invokes volumioStop
+  self.userStopTimer  = null;  // clears userStopFlag after USER_STOP_WINDOW_MS
+  self._origVolumioStop = null; // saved original commandRouter.volumioStop
+  self.fallbackActive = false; // true once fallback playback has been triggered
+  self.savedState     = null;  // snapshot of the lost stream (for auto-restore)
+  self.restoreTimer        = null; // restore-probe interval handle
+  self.restoreConfirmTimer = null; // one-shot confirming-probe handle
+  self._resolveCache       = {};   // original URI -> resolved stream URI
+}
+
+// =============================================================================
+// Lifecycle
+// =============================================================================
+
+StreamWatchdog.prototype.onVolumioStart = function () {
+  var self = this;
+  var configFile = self.commandRouter.pluginManager.getConfigurationFile(
+    self.context, 'config.json'
+  );
+  self.config = new vconf();
+  self.config.loadFile(configFile);
+  return libQ.resolve();
+};
+
+StreamWatchdog.prototype.onStart = function () {
+  var self  = this;
+  var defer = libQ.defer();
+
+  self.logger.info(LOG + 'Plugin starting');
+  self.state         = STATE.IDLE;
+  self.streamUri     = null;
+  self.ready         = false;
+  self._resolveCache = {};
+
+  // Hold off on all logic until MPD and the network have settled.
+  self.startupTimer = setTimeout(function () {
+    self.startupTimer = null;
+    self.ready = true;
+    self.logger.info(LOG + 'Startup delay elapsed — state watcher active');
+    self._connectSocket();
+    self._installStopHook();
+  }, STARTUP_DELAY_MS);
+
+  self.logger.info(LOG + 'Waiting ' + (STARTUP_DELAY_MS / 1000) +
+    's before activating the state watcher');
+
+  defer.resolve();
+  return defer.promise;
+};
+
+StreamWatchdog.prototype.onStop = function () {
+  var self  = this;
+  var defer = libQ.defer();
+
+  self.logger.info(LOG + 'Plugin stopping');
+
+  if (self.startupTimer) {
+    clearTimeout(self.startupTimer);
+    self.startupTimer = null;
+  }
+  if (self.userStopTimer) {
+    clearTimeout(self.userStopTimer);
+    self.userStopTimer = null;
+  }
+  self._stopProbeTimer();
+  self._stopRestoreTimer();
+  self._removeStopHook();
+  self._disconnectSocket();
+
+  self.ready          = false;
+  self.state          = STATE.IDLE;
+  self.streamUri      = null;
+  self.userStopFlag   = false;
+  self.fallbackActive = false;
+  self.savedState     = null;
+  self._resolveCache  = {};
+
+  defer.resolve();
+  return defer.promise;
+};
+
+StreamWatchdog.prototype.getConfigurationFiles = function () {
+  return ['config.json'];
+};
+
+// =============================================================================
+// Layer 1 — State Watcher (socket.io)
+// =============================================================================
+
+StreamWatchdog.prototype._connectSocket = function () {
+  var self = this;
+
+  if (self.socket) return; // already connected
+
+  var io;
+  try {
+    // Reference Volumio's own socket.io-client — never bundle our own copy.
+    io = require('/volumio/node_modules/socket.io-client');
+  } catch (e) {
+    self.logger.error(LOG + 'Could not load socket.io-client: ' + e);
+    return;
+  }
+
+  try {
+    self.socket = io(SOCKET_URL);
+  } catch (e) {
+    self.logger.error(LOG + 'Could not connect to ' + SOCKET_URL + ': ' + e);
+    self.socket = null;
+    return;
+  }
+
+  self.socket.on('connect', function () {
+    self.logger.info(LOG + 'Connected to Volumio socket.io at ' + SOCKET_URL);
+    // Ask Volumio to push the current state so we sync immediately.
+    self.socket.emit('getState', '');
+  });
+
+  self.socket.on('disconnect', function () {
+    self.logger.warn(LOG + 'Disconnected from Volumio socket.io');
+  });
+
+  self.socket.on('pushState', function (state) {
+    try {
+      self._onPushState(state || {});
+    } catch (e) {
+      self.logger.error(LOG + 'Error handling pushState: ' + e);
+    }
+  });
+};
+
+StreamWatchdog.prototype._disconnectSocket = function () {
+  var self = this;
+  if (self.socket) {
+    try {
+      self.socket.removeAllListeners();
+      self.socket.disconnect();
+    } catch (e) {
+      self.logger.warn(LOG + 'Error during socket disconnect: ' + e);
+    }
+    self.socket = null;
+  }
+};
+
+// =============================================================================
+// User-initiated stop detection (see docs/development-plan.md §3.2 A)
+// =============================================================================
+
+/**
+ * Shadows commandRouter.volumioStop so that whenever playback is stopped via
+ * the API, a short-lived flag is raised. The state watcher reads that flag to
+ * tell a deliberate user stop apart from a streaming failure.
+ */
+StreamWatchdog.prototype._installStopHook = function () {
+  var self = this;
+  if (self._origVolumioStop) return; // already installed
+  if (!self.commandRouter || typeof self.commandRouter.volumioStop !== 'function') {
+    self.logger.warn(LOG + 'commandRouter.volumioStop unavailable — user-stop guard disabled');
+    return;
+  }
+  self._origVolumioStop = self.commandRouter.volumioStop;
+  self.commandRouter.volumioStop = function () {
+    self._markUserStop();
+    return self._origVolumioStop.apply(self.commandRouter, arguments);
+  };
+  self.logger.verbose(LOG + 'volumioStop hook installed');
+};
+
+/** Restores the original commandRouter.volumioStop. */
+StreamWatchdog.prototype._removeStopHook = function () {
+  var self = this;
+  if (self._origVolumioStop) {
+    self.commandRouter.volumioStop = self._origVolumioStop;
+    self._origVolumioStop = null;
+  }
+};
+
+/** Raises userStopFlag for USER_STOP_WINDOW_MS, then clears it. */
+StreamWatchdog.prototype._markUserStop = function () {
+  var self = this;
+  self.userStopFlag = true;
+  if (self.userStopTimer) clearTimeout(self.userStopTimer);
+  self.userStopTimer = setTimeout(function () {
+    self.userStopFlag = false;
+    self.userStopTimer = null;
+  }, USER_STOP_WINDOW_MS);
+  if (self.userStopTimer.unref) self.userStopTimer.unref();
+};
+
+/**
+ * Returns true only for a genuine continuous network stream (web radio).
+ *
+ * Volumio sets `state.stream` to boolean `true` ONLY for a duration-0
+ * continuous stream (which it also tags `service: 'webradio'`); for a finite
+ * track it sets `stream` to the track-type STRING ('mp3', 'flac', 'tidal'…).
+ * The `=== true` check MUST stay strict — a truthy test would treat every
+ * local / Tidal / Qobuz / Spotify track as a stream. This is what keeps
+ * token-based services out of WATCHING, so their expiring URLs are never
+ * probed (Phase 7.3).
+ */
+StreamWatchdog.prototype._isStream = function (state) {
+  return state.stream === true || state.service === 'webradio';
+};
+
+/**
+ * Core state machine. Layer 1 (this handler) and Layer 2 (the probe) must
+ * both agree before a failure is confirmed: an unexpected stop moves
+ * WATCHING → SUSPECT, and only a probe failure promotes SUSPECT → FALLBACK.
+ * A stop the user asked for (userStopFlag set) returns straight to IDLE.
+ */
+StreamWatchdog.prototype._onPushState = function (state) {
+  var self = this;
+
+  if (!self.ready) return; // still inside the startup delay
+
+  // A library scan emits pushState with updatedb:true and bogus status values.
+  // Suppress every transition while it is set — see CLAUDE.md.
+  if (state.updatedb === true) {
+    self.logger.verbose(LOG + 'Library scan in progress — ignoring pushState');
+    return;
+  }
+
+  var status   = state.status;
+  var isStream = self._isStream(state);
+
+  // Volumio re-emits pushState in bursts; only log when something meaningful
+  // changed, otherwise the verbose log floods.
+  var sig = status + '|' + state.uri + '|' + state.service + '|' + self.state;
+  if (sig !== self.lastStateSig) {
+    self.lastStateSig = sig;
+    self.logger.verbose(LOG + 'pushState: status=' + status +
+      ' stream=' + state.stream + ' service=' + state.service +
+      ' uri=' + state.uri + ' [state=' + self.state + ']');
+  }
+
+  switch (self.state) {
+
+    case STATE.IDLE:
+      // A network stream started playing → begin watching it.
+      if (status === 'play' && isStream) {
+        self.streamUri = state.uri || null;
+        self._setState(STATE.WATCHING);
+      }
+      break;
+
+    case STATE.WATCHING:
+      if (status === 'play' && isStream) {
+        // Still streaming — keep the watched URI fresh (e.g. station change).
+        if (state.uri && state.uri !== self.streamUri) {
+          self.streamUri = state.uri;
+          self.logger.info(LOG + 'Watched stream URI updated: ' + self.streamUri);
+        }
+      } else if (status === 'play' && !isStream) {
+        // User switched to a local, non-streaming source → plugin goes dormant.
+        self.logger.info(LOG + 'Playback switched to a local source');
+        self.streamUri = null;
+        self._setState(STATE.IDLE);
+      } else if (status === 'stop') {
+        if (self.userStopFlag) {
+          // The user just pressed Stop — deliberate, not a failure.
+          self.logger.info(LOG + 'Stop was user-initiated — returning to IDLE');
+          self.streamUri = null;
+          self._setState(STATE.IDLE);
+        } else {
+          // Unexpected stop — a Layer 1 failure signal. Move to SUSPECT and
+          // fire an immediate Layer 2 probe to confirm or clear it.
+          self.logger.info(LOG + 'Unexpected stop while watching a stream — confirming via probe');
+          self._setState(STATE.SUSPECT);
+          self._runProbe();
+        }
+      }
+      // status === 'pause' → user paused; remain WATCHING.
+      break;
+
+    case STATE.SUSPECT:
+      if (status === 'play' && isStream) {
+        // Stream came back on its own → false alarm.
+        self.logger.info(LOG + 'Stream resumed — false alarm');
+        if (state.uri) self.streamUri = state.uri;
+        self._setState(STATE.WATCHING);
+      } else if (status === 'play' && !isStream) {
+        self.logger.info(LOG + 'Playback switched to a local source');
+        self.streamUri = null;
+        self._setState(STATE.IDLE);
+      }
+      // Otherwise: wait for the probe to confirm (→ FALLBACK) or clear (→ WATCHING).
+      break;
+
+    case STATE.FALLBACK:
+      if (status === 'play' && isStream) {
+        // A stream is playing again — either our auto-restore landed or the
+        // user resumed it manually. Either way, resume watching it.
+        self.logger.info(LOG + 'Stream playing again — resuming watch');
+        self.streamUri = state.uri ||
+          (self.savedState && self.savedState.uri) || null;
+        self._setState(STATE.WATCHING);
+      }
+      // Local fallback playback (service: mpd) keeps us in FALLBACK.
+      break;
+  }
+};
+
+/**
+ * Transitions to a new state and logs it. State changes are logged at info
+ * level; per-cycle detail stays at verbose to avoid log spam.
+ */
+StreamWatchdog.prototype._setState = function (next) {
+  var self = this;
+  if (self.state === next) return;
+  self.logger.info(LOG + self.state + ' → ' + next);
+
+  // The Layer 2 probe runs while WATCHING *and* SUSPECT — keep it running
+  // across that boundary, start it on entry, stop it when leaving for
+  // IDLE or FALLBACK.
+  var wasProbing  = (self.state === STATE.WATCHING || self.state === STATE.SUSPECT);
+  var willProbe   = (next === STATE.WATCHING || next === STATE.SUSPECT);
+  var wasFallback = (self.state === STATE.FALLBACK);
+
+  self.state = next;
+
+  if (next === STATE.WATCHING) self.probeFailCount = 0;
+  if (!wasProbing && willProbe) self._startProbeTimer();
+  if (wasProbing && !willProbe) self._stopProbeTimer();
+
+  // Leaving FALLBACK clears the fallback guard, the saved snapshot, and
+  // stops the restore probe.
+  if (wasFallback && next !== STATE.FALLBACK) {
+    self._stopRestoreTimer();
+    self.fallbackActive = false;
+    self.savedState     = null;
+  }
+  // Entering FALLBACK triggers the local-playback switch.
+  if (next === STATE.FALLBACK) self._enterFallback();
+};
+
+// =============================================================================
+// Layer 2 — HTTP Stream Probe
+// =============================================================================
+
+StreamWatchdog.prototype._startProbeTimer = function () {
+  var self = this;
+  self._stopProbeTimer();
+
+  var interval = parseInt(self._cfg('streamCheckInterval'), 10) || 30;
+  if (interval < MIN_STREAM_INTERVAL) interval = MIN_STREAM_INTERVAL;
+
+  self.logger.info(LOG + 'Stream probe scheduled every ' + interval + 's');
+  self.probeTimer = setInterval(function () { self._runProbe(); }, interval * 1000);
+
+  // Probe once immediately so a failure is caught without waiting a full cycle.
+  self._runProbe();
+};
+
+StreamWatchdog.prototype._stopProbeTimer = function () {
+  var self = this;
+  if (self.probeTimer) {
+    clearInterval(self.probeTimer);
+    self.probeTimer = null;
+  }
+};
+
+/**
+ * Runs one probe cycle against the watched stream URI and drives the Layer 2
+ * side of the state machine:
+ *   - pass in WATCHING  → clear any failure count
+ *   - pass in SUSPECT   → false alarm, back to WATCHING
+ *   - fail in WATCHING  → first signal, move to SUSPECT
+ *   - fail in SUSPECT   → once FAIL_THRESHOLD is reached, confirm → FALLBACK
+ */
+StreamWatchdog.prototype._runProbe = function () {
+  var self = this;
+  if ((self.state !== STATE.WATCHING && self.state !== STATE.SUSPECT) ||
+      !self.streamUri) {
+    return libQ.resolve();
+  }
+
+  return self._resolvedProbe(self.streamUri).then(function (ok) {
+    if (ok) {
+      var hadFailures = self.probeFailCount > 0;
+      self.probeFailCount = 0;
+      if (self.state === STATE.SUSPECT) {
+        self.logger.info(LOG + 'Probe confirms the stream is reachable — false alarm');
+        self._setState(STATE.WATCHING);
+      } else if (hadFailures) {
+        self.logger.info(LOG + 'Stream probe recovered');
+      }
+      return;
+    }
+
+    self.probeFailCount++;
+    self.logger.warn(LOG + 'Stream probe FAILED (' + self.probeFailCount +
+      '/' + FAIL_THRESHOLD + ') — ' + self.streamUri);
+
+    if (self.state === STATE.WATCHING) {
+      // First failure signal from Layer 2 — move to SUSPECT for confirmation.
+      self._setState(STATE.SUSPECT);
+    } else if (self.state === STATE.SUSPECT &&
+               self.probeFailCount >= FAIL_THRESHOLD) {
+      // Both layers now agree the stream is gone.
+      self.logger.error(LOG + 'Stream failure confirmed after ' +
+        self.probeFailCount + ' probe failures — entering FALLBACK');
+      self._setState(STATE.FALLBACK);
+    }
+  });
+};
+
+/**
+ * Sends an HTTP HEAD request to a stream URI and resolves true (reachable) or
+ * false (unreachable). Native http/https only — no external dependencies.
+ *
+ * Pass: 2xx, 3xx, or 405 (Shoutcast/ICEcast servers reject HEAD with 405).
+ * Fail: connection refused, DNS failure, timeout, other 4xx, any 5xx.
+ *
+ * Non-HTTP URIs (e.g. local files, mpd://) are not probeable and resolve true
+ * — Layer 1 still covers them.
+ */
+StreamWatchdog.prototype._probeStream = function (uri) {
+  var self  = this;
+  var defer = libQ.defer();
+
+  var isHttp  = uri && uri.indexOf('http://') === 0;
+  var isHttps = uri && uri.indexOf('https://') === 0;
+
+  if (!isHttp && !isHttps) {
+    self.logger.verbose(LOG + 'Probe skipped — non-HTTP URI: ' + uri);
+    defer.resolve(true);
+    return defer.promise;
+  }
+
+  var settled = false;
+  function finish(ok, reason) {
+    if (settled) return;
+    settled = true;
+    self.logger.verbose(LOG + 'Probe ' + (ok ? 'PASS' : 'FAIL') +
+      ' (' + reason + '): ' + uri);
+    defer.resolve(ok);
+  }
+
+  var parsed, mod;
+  try {
+    parsed = new URL(uri);                       // WHATWG URL — url.parse is deprecated
+    mod    = require(isHttps ? 'https' : 'http');
+  } catch (e) {
+    finish(false, 'bad URI: ' + e.message);
+    return defer.promise;
+  }
+
+  var req;
+  try {
+    req = mod.request(parsed, {
+      method:  'HEAD',
+      headers: { 'User-Agent': 'VolumioStreamWatchdog' }
+    }, function (res) {
+      var code = res.statusCode;
+      var ok   = (code >= 200 && code < 400) || code === 405;
+      res.resume(); // drain so the socket can close
+      finish(ok, 'HTTP ' + code);
+    });
+  } catch (e) {
+    finish(false, 'request error: ' + e.message);
+    return defer.promise;
+  }
+
+  req.setTimeout(PROBE_TIMEOUT_MS, function () {
+    req.destroy();
+    finish(false, 'timeout');
+  });
+  req.on('error', function (err) {
+    finish(false, err.code || err.message);
+  });
+  req.end();
+
+  return defer.promise;
+};
+
+// =============================================================================
+// Layer 2 — Playlist URL resolution
+// =============================================================================
+
+/**
+ * Probes a URI, first resolving it through any .m3u/.pls playlist file so the
+ * HEAD request hits the real stream rather than the (always-reachable)
+ * playlist file. Resolves true (reachable) / false (unreachable).
+ */
+StreamWatchdog.prototype._resolvedProbe = function (uri) {
+  var self = this;
+  return self._resolvePlaylistUri(uri).then(function (target) {
+    return self._probeStream(target);
+  });
+};
+
+/**
+ * If `uri` is an .m3u/.pls playlist file, fetches it and resolves the first
+ * stream URL inside; otherwise resolves `uri` unchanged. Results are cached
+ * so the playlist file is fetched only once per URI.
+ */
+StreamWatchdog.prototype._resolvePlaylistUri = function (uri) {
+  var self  = this;
+  var defer = libQ.defer();
+
+  // Only http(s) URIs can be playlist files we need to fetch.
+  if (!uri || (uri.indexOf('http://') !== 0 && uri.indexOf('https://') !== 0)) {
+    defer.resolve(uri);
+    return defer.promise;
+  }
+  if (self._resolveCache.hasOwnProperty(uri)) {
+    defer.resolve(self._resolveCache[uri]);
+    return defer.promise;
+  }
+
+  var pathname;
+  try {
+    pathname = new URL(uri).pathname.toLowerCase();
+  } catch (e) {
+    defer.resolve(uri);
+    return defer.promise;
+  }
+
+  var isPls = /\.pls$/.test(pathname);
+  var isM3u = /\.m3u$/.test(pathname);
+  if (!isPls && !isM3u) {
+    self._resolveCache[uri] = uri; // a direct stream, not a playlist file
+    defer.resolve(uri);
+    return defer.promise;
+  }
+
+  self._fetchText(uri).then(function (body) {
+    var resolved = self._parsePlaylist(body, isPls);
+    if (resolved) {
+      self.logger.info(LOG + 'Resolved playlist URI ' + uri + ' → ' + resolved);
+    } else {
+      resolved = uri;
+      self.logger.warn(LOG + 'No stream URL found in playlist ' + uri +
+        ' — probing the playlist URI directly');
+    }
+    self._resolveCache[uri] = resolved;
+    defer.resolve(resolved);
+  }).fail(function (err) {
+    self.logger.warn(LOG + 'Could not fetch playlist ' + uri + ' (' + err +
+      ') — probing the playlist URI directly');
+    self._resolveCache[uri] = uri;
+    defer.resolve(uri);
+  });
+
+  return defer.promise;
+};
+
+/**
+ * HTTP GET that resolves the response body as text. Native http/https,
+ * 5-second timeout, body capped at 64 KB (playlist files are tiny).
+ */
+StreamWatchdog.prototype._fetchText = function (uri) {
+  var self  = this;
+  var defer = libQ.defer();
+  var isHttps = uri.indexOf('https://') === 0;
+
+  var mod, parsed;
+  try {
+    parsed = new URL(uri);
+    mod    = require(isHttps ? 'https' : 'http');
+  } catch (e) {
+    defer.reject('bad URI');
+    return defer.promise;
+  }
+
+  var settled = false;
+  function done(err, text) {
+    if (settled) return;
+    settled = true;
+    if (err) defer.reject(err);
+    else defer.resolve(text);
+  }
+
+  var req = mod.get(parsed, function (res) {
+    if (res.statusCode >= 400) {
+      res.resume();
+      done('HTTP ' + res.statusCode);
+      return;
+    }
+    var body = '';
+    res.setEncoding('utf8');
+    res.on('data', function (chunk) {
+      body += chunk;
+      if (body.length > 65536) { // playlist files are tiny — cap the read
+        req.destroy();
+        done(null, body);
+      }
+    });
+    res.on('end', function () { done(null, body); });
+  });
+  req.setTimeout(PROBE_TIMEOUT_MS, function () {
+    req.destroy();
+    done('timeout');
+  });
+  req.on('error', function (e) { done(e.code || e.message); });
+
+  return defer.promise;
+};
+
+/**
+ * Extracts the first http(s) stream URL from an .m3u or .pls playlist body.
+ * Returns null if none is found.
+ */
+StreamWatchdog.prototype._parsePlaylist = function (body, isPls) {
+  var lines = String(body || '').split(/\r?\n/);
+  for (var i = 0; i < lines.length; i++) {
+    var line = lines[i].trim();
+    if (!line) continue;
+
+    var candidate = null;
+    if (isPls) {
+      // .pls is INI-style: "File1=http://stream..."
+      var m = line.match(/^File\d*\s*=\s*(\S.*)$/i);
+      if (m) candidate = m[1].trim();
+    } else {
+      // .m3u: the first non-comment line
+      if (line.charAt(0) === '#') continue;
+      candidate = line;
+    }
+    if (candidate && /^https?:\/\//i.test(candidate)) return candidate;
+  }
+  return null;
+};
+
+// =============================================================================
+// Phase 4 — Fallback playback
+// =============================================================================
+
+/**
+ * Switches playback to local music after a confirmed stream failure. Called
+ * once when the state machine enters FALLBACK.
+ *
+ * volumioStop / volumioClearQueue are fire-and-forget in Volumio 4 — they
+ * must NOT be chained with .then(); the steps are sequenced with setTimeout
+ * (see CLAUDE.md).
+ */
+StreamWatchdog.prototype._enterFallback = function () {
+  var self = this;
+  if (self.fallbackActive) return; // guard against re-entry
+  self.fallbackActive = true;
+
+  // Snapshot the lost stream so Phase 5 can restore it.
+  try {
+    self.savedState = self.commandRouter.volumioGetState();
+  } catch (e) {
+    self.logger.warn(LOG + 'Could not snapshot playback state: ' + e);
+    self.savedState = null;
+  }
+
+  self.commandRouter.pushToastMessage('warning', 'Stream Watchdog',
+    'Stream lost — switching to local music.');
+
+  try {
+    self.commandRouter.volumioStop();
+  } catch (e) {
+    self.logger.error(LOG + 'volumioStop failed: ' + e);
+  }
+
+  setTimeout(function () {
+    if (!self.ready) return; // plugin stopped mid-sequence
+    try {
+      self.commandRouter.volumioClearQueue();
+    } catch (e) {
+      self.logger.error(LOG + 'volumioClearQueue failed: ' + e);
+    }
+    setTimeout(function () {
+      if (self.ready) self._playOfflinePlaylist();
+    }, FALLBACK_STEP_MS);
+  }, FALLBACK_STEP_MS);
+
+  // Begin watching for the original stream to come back.
+  self._startRestoreTimer();
+};
+
+/**
+ * Plays the configured Volumio playlist. If no playlist by that name exists,
+ * falls back to scanning the local music library.
+ */
+StreamWatchdog.prototype._playOfflinePlaylist = function () {
+  var self = this;
+  var name = self._cfg('offlinePlaylistName') || 'Offline';
+
+  var playlists = [];
+  try {
+    if (self.commandRouter.playListManager &&
+        typeof self.commandRouter.playListManager.retrievePlaylists === 'function') {
+      playlists = self.commandRouter.playListManager.retrievePlaylists() || [];
+    }
+  } catch (e) {
+    self.logger.warn(LOG + 'Could not list playlists: ' + e);
+  }
+
+  if (playlists.indexOf(name) !== -1) {
+    self.logger.info(LOG + 'Playing offline playlist "' + name + '"');
+    try {
+      self.commandRouter.playPlaylist(name);
+    } catch (e) {
+      self.logger.error(LOG + 'playPlaylist failed: ' + e);
+      return self._playLocalFolder();
+    }
+    return libQ.resolve();
+  }
+
+  self.logger.warn(LOG + 'Playlist "' + name +
+    '" not found — falling back to a local library scan');
+  self.commandRouter.pushToastMessage('warning', 'Stream Watchdog',
+    'Playlist "' + name + '" not found — playing local music instead.');
+  return self._playLocalFolder();
+};
+
+/**
+ * Fallback when no Offline playlist exists: recursively browse the local
+ * library, queue every track found, and start playback.
+ */
+StreamWatchdog.prototype._playLocalFolder = function () {
+  var self = this;
+  self.logger.info(LOG + 'Scanning local library: ' + LOCAL_LIBRARY_URI);
+
+  return self._collectTracks(LOCAL_LIBRARY_URI).then(function (items) {
+    if (!self.ready) return; // plugin stopped during the scan
+    if (!items || items.length === 0) {
+      self.logger.warn(LOG + 'No local tracks found at ' + LOCAL_LIBRARY_URI);
+      self.commandRouter.pushToastMessage('error', 'Stream Watchdog',
+        'No local music found. Create a playlist named "' +
+        (self._cfg('offlinePlaylistName') || 'Offline') + '".');
+      return;
+    }
+
+    self.logger.info(LOG + 'Queuing ' + items.length + ' local track(s)');
+    try {
+      self.commandRouter.addQueueItems(items); // fire-and-forget
+    } catch (e) {
+      self.logger.error(LOG + 'addQueueItems failed: ' + e);
+      return;
+    }
+    setTimeout(function () {
+      if (!self.ready) return;
+      try {
+        self.commandRouter.volumioPlay();
+      } catch (e) {
+        self.logger.error(LOG + 'volumioPlay failed: ' + e);
+      }
+    }, FALLBACK_STEP_MS);
+  }).fail(function (err) {
+    self.logger.error(LOG + 'Local library scan failed: ' + err);
+  });
+};
+
+/**
+ * Recursively browses `uri` via the MPD plugin and resolves an array of all
+ * playable track items found beneath it.
+ */
+StreamWatchdog.prototype._collectTracks = function (uri) {
+  var self = this;
+
+  // The MPD plugin's browse method is handleBrowseUri(curUri) — a URI string,
+  // not an object, and not 'browseUri' (which does not exist).
+  var browseResult;
+  try {
+    browseResult = self.commandRouter.executeOnPlugin(
+      'music_service', 'mpd', 'handleBrowseUri', uri);
+  } catch (e) {
+    self.logger.error(LOG + 'executeOnPlugin(handleBrowseUri) threw: ' + e);
+    return libQ.resolve([]);
+  }
+
+  if (!browseResult || typeof browseResult.then !== 'function') {
+    self.logger.warn(LOG + 'handleBrowseUri returned no promise for: ' + uri);
+    return libQ.resolve([]);
+  }
+
+  return browseResult.then(function (result) {
+    var tracks  = [];
+    var folders = [];
+
+    if (!result || !result.navigation) return tracks;
+
+    (result.navigation.lists || []).forEach(function (list) {
+      (list.items || []).forEach(function (item) {
+        if (item.type === 'song' || item.type === 'audio-file') {
+          tracks.push(item);
+        } else if (item.uri && FOLDER_TYPES.indexOf(item.type) !== -1) {
+          folders.push(item.uri);
+        }
+      });
+    });
+
+    if (folders.length === 0) return tracks;
+
+    return libQ.all(folders.map(function (folderUri) {
+      return self._collectTracks(folderUri);
+    })).then(function (results) {
+      results.forEach(function (sub) { tracks = tracks.concat(sub); });
+      return tracks;
+    });
+  });
+};
+
+// =============================================================================
+// Phase 5 — Auto-restore
+// =============================================================================
+
+StreamWatchdog.prototype._startRestoreTimer = function () {
+  var self = this;
+  self._stopRestoreTimer();
+
+  var interval = parseInt(self._cfg('restoreCheckInterval'), 10) || 60;
+  if (interval < MIN_RESTORE_INTERVAL) interval = MIN_RESTORE_INTERVAL;
+
+  self.logger.info(LOG + 'Restore probe scheduled every ' + interval + 's');
+  // No immediate probe — the stream just failed; wait a full interval.
+  self.restoreTimer = setInterval(function () {
+    self._runRestoreProbe();
+  }, interval * 1000);
+};
+
+StreamWatchdog.prototype._stopRestoreTimer = function () {
+  var self = this;
+  if (self.restoreTimer) {
+    clearInterval(self.restoreTimer);
+    self.restoreTimer = null;
+  }
+  if (self.restoreConfirmTimer) {
+    clearTimeout(self.restoreConfirmTimer);
+    self.restoreConfirmTimer = null;
+  }
+};
+
+/**
+ * One restore-probe cycle: probes the saved stream URI. A pass schedules a
+ * confirming probe RESTORE_CONFIRM_MS later — two consecutive passes are
+ * required before the stream is restored.
+ */
+StreamWatchdog.prototype._runRestoreProbe = function () {
+  var self = this;
+  if (self.state !== STATE.FALLBACK) return libQ.resolve();
+  if (!self.savedState || !self.savedState.uri) {
+    self.logger.verbose(LOG + 'No saved stream URI — cannot probe for restore');
+    return libQ.resolve();
+  }
+
+  return self._resolvedProbe(self.savedState.uri).then(function (ok) {
+    if (!ok) {
+      self.logger.verbose(LOG + 'Restore probe: stream still down');
+      return;
+    }
+    self.logger.info(LOG + 'Restore probe passed — confirming in ' +
+      (RESTORE_CONFIRM_MS / 1000) + 's');
+    if (self.restoreConfirmTimer) clearTimeout(self.restoreConfirmTimer);
+    self.restoreConfirmTimer = setTimeout(function () {
+      self.restoreConfirmTimer = null;
+      self._confirmRestore();
+    }, RESTORE_CONFIRM_MS);
+  });
+};
+
+/** Second of the two consecutive probes; a pass triggers the restore. */
+StreamWatchdog.prototype._confirmRestore = function () {
+  var self = this;
+  if (self.state !== STATE.FALLBACK) return libQ.resolve();
+  if (!self.savedState || !self.savedState.uri) return libQ.resolve();
+
+  return self._resolvedProbe(self.savedState.uri).then(function (ok) {
+    if (!ok) {
+      self.logger.info(LOG + 'Restore not confirmed — stream down again');
+      return;
+    }
+    self._restoreStream();
+  });
+};
+
+/**
+ * The saved stream is confirmed reachable. With autoRestore on, resume it;
+ * otherwise just notify and stay in FALLBACK.
+ */
+StreamWatchdog.prototype._restoreStream = function () {
+  var self  = this;
+  var saved = self.savedState;
+  if (!saved || !saved.uri) return;
+
+  self._stopRestoreTimer(); // don't fire again while restoring
+
+  if (!self._cfg('autoRestore')) {
+    self.logger.info(LOG + 'Stream is back, but auto-restore is disabled');
+    self.commandRouter.pushToastMessage('success', 'Stream Watchdog',
+      'Stream is back online — resume it manually.');
+    return; // stay in FALLBACK; a manual resume moves us back to WATCHING
+  }
+
+  self.logger.info(LOG + 'Restoring original stream: ' + saved.uri);
+  self.commandRouter.pushToastMessage('success', 'Stream Watchdog',
+    'Stream restored — resuming.');
+
+  var item = { uri: saved.uri, service: saved.service, title: saved.title };
+
+  if (typeof self.commandRouter.replaceAndPlay === 'function') {
+    try {
+      self.commandRouter.replaceAndPlay(item);
+      return;
+    } catch (e) {
+      self.logger.error(LOG + 'replaceAndPlay failed: ' + e);
+    }
+  }
+  // Older Volumio builds without replaceAndPlay: stop/clear/add/play.
+  self._restoreViaQueue(item);
+};
+
+/** Fallback resume path when replaceAndPlay is unavailable. */
+StreamWatchdog.prototype._restoreViaQueue = function (item) {
+  var self = this;
+  self.logger.info(LOG + 'Restoring via stop/clear/add/play');
+
+  try { self.commandRouter.volumioStop(); }
+  catch (e) { self.logger.error(LOG + 'volumioStop failed: ' + e); }
+
+  setTimeout(function () {
+    if (!self.ready) return; // plugin stopped mid-sequence
+    try { self.commandRouter.volumioClearQueue(); }
+    catch (e) { self.logger.error(LOG + 'volumioClearQueue failed: ' + e); }
+
+    setTimeout(function () {
+      if (!self.ready) return;
+      try { self.commandRouter.addQueueItems([item]); }
+      catch (e) { self.logger.error(LOG + 'addQueueItems failed: ' + e); }
+
+      setTimeout(function () {
+        if (!self.ready) return;
+        try { self.commandRouter.volumioPlay(); }
+        catch (e) { self.logger.error(LOG + 'volumioPlay failed: ' + e); }
+      }, FALLBACK_STEP_MS);
+    }, FALLBACK_STEP_MS);
+  }, FALLBACK_STEP_MS);
+};
+
+// =============================================================================
+// Configuration
+// =============================================================================
+
+/**
+ * v-conf may return either a raw value or a {type, value} object depending on
+ * version and how the config was last written. Always unwrap via this helper.
+ */
+StreamWatchdog.prototype._cfg = function (key) {
+  var val = this.config.get(key);
+  if (val !== null && typeof val === 'object' && 'value' in val) {
+    return val.value;
+  }
+  return val;
+};
+
+StreamWatchdog.prototype.getUIConfig = function () {
+  var self      = this;
+  var defer     = libQ.defer();
+  var lang_code = self.commandRouter.sharedVars.get('language_code');
+
+  self.commandRouter.i18nJson(
+    __dirname + '/i18n/strings_' + lang_code + '.json',
+    __dirname + '/i18n/strings_en.json',
+    __dirname + '/UIConfig.json'
+  ).then(function (uiconf) {
+    var content = uiconf.sections[0].content;
+    content[0].value = self._cfg('offlinePlaylistName');
+    content[1].value = self._cfg('streamCheckInterval');
+    content[2].value = self._cfg('restoreCheckInterval');
+    content[3].value = self._cfg('autoRestore');
+    defer.resolve(uiconf);
+  }).fail(function (e) {
+    self.logger.error(LOG + 'getUIConfig failed: ' + e);
+    defer.reject(new Error());
+  });
+
+  return defer.promise;
+};
+
+StreamWatchdog.prototype.setUIConfig = function (data) {
+  return libQ.resolve();
+};
+
+/**
+ * Save handler for the settings section. Wired via the section's `onSave`
+ * (in UIConfig.json); Volumio collects the fields named in `saveButton.data`
+ * and passes their current values here as a plain object.
+ */
+StreamWatchdog.prototype.savePluginConfig = function (data) {
+  var self = this;
+  data = data || {};
+
+  // Read each value from `data`, falling back to the stored value if a
+  // field is somehow absent.
+  var playlist = (data.offlinePlaylistName !== undefined && data.offlinePlaylistName !== null)
+    ? String(data.offlinePlaylistName).trim()
+    : self._cfg('offlinePlaylistName');
+  if (!playlist) playlist = 'Offline';
+
+  var streamInterval = parseInt(data.streamCheckInterval, 10);
+  if (isNaN(streamInterval)) {
+    streamInterval = parseInt(self._cfg('streamCheckInterval'), 10) || 30;
+  }
+  var restoreInterval = parseInt(data.restoreCheckInterval, 10);
+  if (isNaN(restoreInterval)) {
+    restoreInterval = parseInt(self._cfg('restoreCheckInterval'), 10) || 60;
+  }
+  var autoRestore = (data.autoRestore !== undefined)
+    ? (data.autoRestore === true || data.autoRestore === 'true')
+    : !!self._cfg('autoRestore');
+
+  // Volumio cannot refresh an open settings modal, so the toast has to be
+  // the feedback — name exactly which value was raised.
+  var notes = [];
+  if (streamInterval < MIN_STREAM_INTERVAL) {
+    streamInterval = MIN_STREAM_INTERVAL;
+    notes.push('Stream Check raised to ' + MIN_STREAM_INTERVAL + 's');
+  }
+  if (restoreInterval < MIN_RESTORE_INTERVAL) {
+    restoreInterval = MIN_RESTORE_INTERVAL;
+    notes.push('Restore Check raised to ' + MIN_RESTORE_INTERVAL + 's');
+  }
+
+  self.config.set('offlinePlaylistName', playlist);
+  self.config.set('streamCheckInterval', streamInterval);
+  self.config.set('restoreCheckInterval', restoreInterval);
+  self.config.set('autoRestore', autoRestore);
+  self.config.save();
+
+  self.logger.info(LOG + 'savePluginConfig — playlist="' + playlist +
+    '" streamCheck=' + streamInterval + 's restoreCheck=' + restoreInterval +
+    's autoRestore=' + autoRestore);
+
+  // Apply the new intervals to the timer that is running right now.
+  if (self.state === STATE.WATCHING || self.state === STATE.SUSPECT) {
+    self._startProbeTimer();
+  } else if (self.state === STATE.FALLBACK) {
+    self._startRestoreTimer();
+  }
+
+  self.commandRouter.pushToastMessage('success', 'Stream Watchdog',
+    notes.length ? 'Settings saved — ' + notes.join('; ') + ' (minimum allowed).'
+                 : 'Settings saved.');
+};

--- a/volumio-stream-watchdog/install.sh
+++ b/volumio-stream-watchdog/install.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+echo "Installing Stream Watchdog plugin"
+echo "No external dependencies required"
+
+# Ensure plugin directory permissions are correct
+chmod -R 755 /data/plugins/miscellanea/volumio-stream-watchdog
+
+echo "plugininstallend"

--- a/volumio-stream-watchdog/install.sh
+++ b/volumio-stream-watchdog/install.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
-echo "Installing Stream Watchdog plugin"
-echo "No external dependencies required"
-
-# Ensure plugin directory permissions are correct
-chmod -R 755 /data/plugins/miscellanea/volumio-stream-watchdog
+# Stream Watchdog has no system packages to install.
+echo "Installing Stream Watchdog"
 
 echo "plugininstallend"

--- a/volumio-stream-watchdog/package-lock.json
+++ b/volumio-stream-watchdog/package-lock.json
@@ -1,0 +1,108 @@
+{
+  "name": "volumio-stream-watchdog",
+  "version": "0.2.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "volumio-stream-watchdog",
+      "version": "0.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "kew": "^0.7.0",
+        "v-conf": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=8",
+        "volumio": ">=3"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+      "integrity": "sha512-V3Z3WZWVUYd8hoCL5xfXJCaHWYzmtwW5XWYSlLgERi8PWd8bx1kUHUk8L1BT57e49oKnDDD180mjfrHc1yA9rg==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^3.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+      "integrity": "sha512-oBko6ZHlubVB5mRFkur5vgYR1UyqX+S6Y/oCfLhqNdcc2fYFlDpIoNc7AfKS1KOGcnNAkvsr0grLck9ANM815w==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/kew": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
+      "integrity": "sha512-IG6nm0+QtAMdXt9KvbgbGdvY50RSrw+U4sGZg+KlrSKPJEwVE5JVoI3d7RWfSMdBQneRheeAOj3lIjX5VL/9RQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/multimap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/multimap/-/multimap-1.0.1.tgz",
+      "integrity": "sha512-3BA0yy/HC53U1emi32s5Kk78bwDG70Hdx4TkPFSCFTNXqsDR10VoX3zJb2Kn+L6U4X929q8WChzEy2HeI7l1Bg==",
+      "license": "MIT"
+    },
+    "node_modules/slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==",
+      "license": "ISC",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/v-conf": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/v-conf/-/v-conf-1.4.3.tgz",
+      "integrity": "sha512-jhnAhXDbzorq3pkoqrOzbiLP0yO4rxlfmWUvUuffDM6Dz6YZRN/LfzS1WmvJOFeq8CWapLRyO2std/U2VsOpBg==",
+      "license": "GPLV3",
+      "dependencies": {
+        "fs-extra": "^3.0.1",
+        "multimap": "1.0.1",
+        "write-file-atomic": "1.3.1"
+      }
+    },
+    "node_modules/write-file-atomic": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.1.tgz",
+      "integrity": "sha512-RCTmbZJFENrUmJVmdaf3SiIDlP1YQGFub6P/WbrTxKHKLWmhnSgaM/cYsjxDwnzD0gVE2tlTUpX6Zr/9V4+DQg==",
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "slide": "^1.1.5"
+      }
+    }
+  }
+}

--- a/volumio-stream-watchdog/package.json
+++ b/volumio-stream-watchdog/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "volumio-stream-watchdog",
+  "version": "1.0.0",
+  "description": "Automatically switches to a local playlist when your stream fails, and resumes when it returns.",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --test '__tests__/**/*.test.js'",
+    "test:l0": "node --test '__tests__/L0/**/*.test.js'",
+    "test:l1": "node --test '__tests__/L1/**/*.test.js'"
+  },
+  "author": "josemathias",
+  "license": "MIT",
+  "repository": "https://github.com/josemathias/volumio-plugins-sources-bookworm",
+  "volumio_info": {
+    "prettyName": "Stream Watchdog",
+    "icon": "fa-wifi",
+    "plugin_type": "miscellanea",
+    "architectures": [
+      "amd64",
+      "armhf"
+    ],
+    "os": [
+      "bookworm"
+    ],
+    "has_alsa_contribution": false,
+    "boot_priority": 100,
+    "details": "Monitors your web radio or streaming source and automatically switches to a curated local Volumio playlist when the stream fails. Uses Volumio's own player state events and direct HTTP stream probing — not a generic TCP ping — so it catches failures that network checks miss. Resumes the original stream automatically when connectivity is restored.",
+    "changelog": "1.0.0 — Initial release"
+  },
+  "engines": {
+    "node": ">=20",
+    "volumio": ">=4"
+  },
+  "dependencies": {
+    "kew": "^0.7.0",
+    "v-conf": "^1.4.0"
+  }
+}

--- a/volumio-stream-watchdog/package.json
+++ b/volumio-stream-watchdog/package.json
@@ -14,7 +14,7 @@
   "volumio_info": {
     "prettyName": "Stream Watchdog",
     "icon": "fa-wifi",
-    "plugin_type": "miscellanea",
+    "plugin_type": "system_controller",
     "architectures": [
       "amd64",
       "armhf"

--- a/volumio-stream-watchdog/uninstall.sh
+++ b/volumio-stream-watchdog/uninstall.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo "Uninstalling Stream Watchdog plugin"
+echo "No external dependencies to remove"
+
+echo "pluginuninstallend"


### PR DESCRIPTION
Adds **Stream Watchdog** (`volumio-stream-watchdog`, v1.0.0) — a `miscellanea` plugin for Volumio 4 / bookworm.

It detects genuine web-radio streaming failure — using Volumio's own `pushState` events plus a direct HTTP probe of the stream URL, not a generic network ping — and automatically switches to a configured local Volumio playlist. When the original stream recovers, it resumes automatically.

- No external or native dependencies — Node `http`/`https` built-ins; `socket.io-client`/`kew`/`v-conf` referenced from Volumio.
- Clean `onStart`/`onStop` lifecycle: all timers, the socket and the command hook are torn down; no writes outside the plugin directory.
- `.m3u`/`.pls` stream URIs are resolved to the real stream before probing.
- Settings: offline playlist name, stream/restore check intervals, auto-restore toggle.
- `bookworm`, `amd64`/`armhf`.

Initial submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)