### PR TITLE
Add Korean Radio Alarm plugin

### DIFF
--- a/korean_radio_alarm/.gitignore
+++ b/korean_radio_alarm/.gitignore
@@ -1,0 +1,13 @@
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+logs/
+*.log
+coverage/
+.temp/
+tmp/
+.DS_Store
+Thumbs.db
+*.tgz
+*.tar.gz

--- a/korean_radio_alarm/LICENSE
+++ b/korean_radio_alarm/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 rightway-p
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/korean_radio_alarm/README.md
+++ b/korean_radio_alarm/README.md
@@ -1,0 +1,69 @@
+# Korean Radio Alarm
+
+A Volumio 4 Bookworm music service plugin that adds Korean radio browsing plus a weekly alarm scheduler.
+
+## Features
+
+- Browse grouped Korean radio stations in the Volumio browse section.
+- Configure an unlimited number of independent alarm slots (dynamic add/delete from the UI).
+- Slots support their own time, station, volume, and weekday schedule.
+- Each slot can be configured to play a station or stop playback when it triggers.
+- Volumio 4 Bookworm compatibility (`engines.node >= 20`, `volumio >= 4`, `os: ["bookworm"]`).
+- No additional system dependencies and no runtime writes to `/volumio` or `/myvolumio`.
+- KBS stations resolve through the KBS play API and memoize stream URLs in-memory during runtime, which can reduce repeated stream start latency without changing playback behavior.
+
+## Included stations
+
+- KBS
+  - KBS Classic FM
+  - KBS Cool FM
+  - KBS Hanminjok
+  - KBS World Radio
+- News
+  - YTN Radio
+- Music
+  - CBS Music FM
+
+`MBC`, `SBS`, and `Listen.moe K-pop` are currently omitted because stream stability and playback compatibility need additional validation before re-adding.
+
+## Default config for dynamic alarm slots
+
+`config.json` ships with defaults for `alarm_ids` and `alarm_1`.
+
+- `alarm_ids`: comma-separated active slot IDs (`alarm_1` by default)
+- `alarm_1`: enabled=false, weekdays Mon-Fri=true, Sat/Sun=false
+- all slots use `korean_radio_alarm://station/kbs-classic-fm` as default station
+
+Legacy single-slot config keys are still supported for migration.
+
+## Install / test / uninstall (local repo)
+
+```bash
+cd /path/to/korean_radio_alarm
+npm ci
+npm test
+```
+
+You can install directly from the plugin folder on a Bookworm device:
+
+```bash
+# from device/remote shell
+cd /path/to/korean_radio_alarm
+volumio plugin install .
+```
+
+## Volumio submission checklist
+
+- Use only repository defaults for Bookworm submission (`bookworm`, amd64/armhf, node>=20).
+- Keep plugin entrypoints (`install.sh`, `uninstall.sh`, `config.json`, `UIConfig.json`) and lockfiles committed.
+- Avoid external apt packages and avoid writing outside plugin-scoped directories.
+- Verify no system-level side effects.
+- Validate station catalogue and defaults align with submit-ready constraints.
+
+See full checklist in [`docs/submission-checklist.md`](docs/submission-checklist.md).
+
+## Known limitations
+
+- Radio stream endpoints can change without notice.
+- This repo intentionally omits `MBC`, `SBS`, and `Listen.moe K-pop` until stream stability is revalidated.
+- Dynamic endpoint failures should surface naturally and be reviewed before re-enabling stations.

--- a/korean_radio_alarm/UIConfig.json
+++ b/korean_radio_alarm/UIConfig.json
@@ -1,0 +1,33 @@
+{
+  "page": {
+    "label": "TRANSLATE.PAGE.LABEL"
+  },
+  "onSave": {
+    "type": "controller",
+    "endpoint": "music_service/korean_radio_alarm",
+    "method": "saveAlarm"
+  },
+  "sections": [
+    {
+      "id": "alarm_actions",
+      "element": "section",
+      "label": "TRANSLATE.SECTION.ALARM",
+      "content": [
+        {
+          "element": "button",
+          "id": "alarm_actions_add",
+          "label": "TRANSLATE.BUTTON.ADD_ALARM",
+          "onClick": {
+            "type": "emit",
+            "message": "callMethod",
+            "data": {
+              "endpoint": "music_service/korean_radio_alarm",
+              "method": "addAlarm",
+              "data": {}
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/korean_radio_alarm/config.json
+++ b/korean_radio_alarm/config.json
@@ -1,0 +1,58 @@
+{
+  "alarm_ids": {
+    "type": "string",
+    "value": "alarm_1"
+  },
+  "alarm_1_enabled": {
+    "type": "boolean",
+    "value": false
+  },
+  "alarm_1_hour": {
+    "type": "number",
+    "value": 7
+  },
+  "alarm_1_minute": {
+    "type": "number",
+    "value": 0
+  },
+  "alarm_1_station_uri": {
+    "type": "string",
+    "value": "korean_radio_alarm://station/kbs-classic-fm"
+  },
+  "alarm_1_volume": {
+    "type": "number",
+    "value": 45
+  },
+  "alarm_1_action": {
+    "type": "string",
+    "value": "play"
+  },
+  "alarm_1_monday": {
+    "type": "boolean",
+    "value": true
+  },
+  "alarm_1_tuesday": {
+    "type": "boolean",
+    "value": true
+  },
+  "alarm_1_wednesday": {
+    "type": "boolean",
+    "value": true
+  },
+  "alarm_1_thursday": {
+    "type": "boolean",
+    "value": true
+  },
+  "alarm_1_friday": {
+    "type": "boolean",
+    "value": true
+  },
+  "alarm_1_saturday": {
+    "type": "boolean",
+    "value": false
+  },
+  "alarm_1_sunday": {
+    "type": "boolean",
+    "value": false
+  }
+}

--- a/korean_radio_alarm/docs/submission-checklist.md
+++ b/korean_radio_alarm/docs/submission-checklist.md
@@ -1,0 +1,48 @@
+# Volumio Bookworm Submission Checklist
+
+## Plugin/package prep
+
+- [ ] Confirm plugin manifest metadata:
+  - `engines.node >= 20`
+  - `volumio >= 4`
+  - `volumio_info.os = ["bookworm"]`
+  - `architectures = ["amd64", "armhf"]`
+- [ ] Verify package version and lockfile version are aligned (`0.1.3`).
+- [ ] Verify install/uninstall scripts are executable.
+- [ ] Verify default `config.json` contains `alarm_ids` and `alarm_1`.
+
+## Local validation
+
+- [ ] `cd /path/to/korean_radio_alarm`
+- [ ] `npm ci`
+- [ ] `npm test`
+
+## Source repo sync
+
+- [ ] `cd /path/to`
+- [ ] `git clone <your-fork> volumio-plugins-sources-bookworm`
+- [ ] `cd volumio-plugins-sources-bookworm`
+- [ ] Copy the plugin folder into the root of your forked source tree:
+  - `cp -R /path/to/korean_radio_alarm .`
+- [ ] Open PR in your fork for Bookworm plugin-sources tree.
+
+## Device validation (Bookworm)
+
+- [ ] On Bookworm device, install plugin from the forked tree or via plugin manager flow.
+- [ ] Verify browse view lists station groups and station items.
+- [ ] Playback test:
+  - open `kbs-classic-fm`, `cbs-music-fm`, and one stream with resolver if available
+  - confirm playback starts and track metadata appears in player UI
+- [ ] Alarm persistence test:
+  - enable `alarm_1` for current minute +1 and matching weekday
+  - wait for trigger
+  - confirm alarm wakes and plays selected station
+  - confirm `alarm_ids` and saved alarm slot values persist after restart
+- [ ] Uninstall test:
+  - run uninstall flow and confirm no browse source remains
+
+## Cleanup
+
+- [ ] On plugin source device/worktree: remove dependency artifacts before committing final PR (`rm -rf node_modules`).
+- [ ] Submit PR from fork and include test outputs.
+- [ ] Run Bookworm submission flow from your Volumio environment (`volumio plugin submit` path for your deployment).

--- a/korean_radio_alarm/i18n/strings_en.json
+++ b/korean_radio_alarm/i18n/strings_en.json
@@ -1,0 +1,51 @@
+{
+  "PAGE": {
+    "LABEL": "Korean Radio Alarm"
+  },
+  "SECTION": {
+    "ALARM": "Alarm",
+    "ALARM_SLOT_1": "Alarm 1",
+    "ALARM_SLOT_2": "Alarm 2",
+    "ALARM_SLOT_3": "Alarm 3",
+    "ALARM_SLOT": "Alarm Slot"
+  },
+  "BUTTON": {
+    "SAVE": "Save",
+    "ADD_ALARM": "Add alarm",
+    "DELETE_ALARM": "Delete alarm"
+  },
+  "ALARM": {
+    "TITLE": "Korean Radio Alarm",
+    "ADD_SUCCESS": "Alarm added successfully",
+    "DELETE_MISSING_SLOT": "No slot provided",
+    "DELETE_SUCCESS": "Alarm deleted successfully",
+    "ENABLED": "Enable alarm",
+    "ACTION": "Alarm action",
+    "ACTION_PLAY": "Play",
+    "ACTION_STOP": "Stop",
+    "HOUR": "Hour",
+    "MINUTE": "Minute",
+    "STATION": "Station",
+    "VOLUME": "Alarm volume",
+    "SAVE_SUCCESS": "Alarm settings saved and rescheduled",
+    "SAVE_ERROR": "Failed to save alarm settings",
+    "NO_STATION": "Selected station is not valid",
+    "NO_MPD": "MPD plugin is not available",
+    "NO_URI": "Could not resolve station URL",
+    "BAD_VOLUME": "Invalid alarm volume",
+    "NOT_CONFIGURED": "No station configured"
+  },
+  "WEEKDAY": {
+    "MONDAY": "Monday",
+    "TUESDAY": "Tuesday",
+    "WEDNESDAY": "Wednesday",
+    "THURSDAY": "Thursday",
+    "FRIDAY": "Friday",
+    "SATURDAY": "Saturday",
+    "SUNDAY": "Sunday"
+  },
+  "BROWSE": {
+    "ROOT": "Korean Radio",
+    "GROUPS": "Radio Groups"
+  }
+}

--- a/korean_radio_alarm/i18n/strings_ko.json
+++ b/korean_radio_alarm/i18n/strings_ko.json
@@ -1,0 +1,51 @@
+{
+  "PAGE": {
+    "LABEL": "Korean Radio Alarm"
+  },
+  "SECTION": {
+    "ALARM": "알림 시계",
+    "ALARM_SLOT_1": "알림 1",
+    "ALARM_SLOT_2": "알림 2",
+    "ALARM_SLOT_3": "알림 3",
+    "ALARM_SLOT": "알림"
+  },
+  "BUTTON": {
+    "SAVE": "저장",
+    "ADD_ALARM": "알람 추가",
+    "DELETE_ALARM": "알람 삭제"
+  },
+  "ALARM": {
+    "TITLE": "Korean Radio Alarm",
+    "ADD_SUCCESS": "알람이 추가되었습니다",
+    "DELETE_MISSING_SLOT": "슬롯 정보가 없습니다",
+    "DELETE_SUCCESS": "알람이 삭제되었습니다",
+    "ENABLED": "알람 사용",
+    "ACTION": "동작",
+    "ACTION_PLAY": "켜기",
+    "ACTION_STOP": "끄기",
+    "HOUR": "시",
+    "MINUTE": "분",
+    "STATION": "방송국",
+    "VOLUME": "재생 볼륨",
+    "SAVE_SUCCESS": "알람 설정이 저장되고 다시 적용되었습니다",
+    "SAVE_ERROR": "알람 설정 저장에 실패했습니다",
+    "NO_STATION": "선택한 방송국이 유효하지 않습니다",
+    "NO_MPD": "MPD 플러그인을 찾을 수 없습니다",
+    "NO_URI": "재생 URL을 확인할 수 없습니다",
+    "BAD_VOLUME": "유효하지 않은 볼륨 값",
+    "NOT_CONFIGURED": "설정된 방송국이 없습니다"
+  },
+  "WEEKDAY": {
+    "MONDAY": "월",
+    "TUESDAY": "화",
+    "WEDNESDAY": "수",
+    "THURSDAY": "목",
+    "FRIDAY": "금",
+    "SATURDAY": "토",
+    "SUNDAY": "일"
+  },
+  "BROWSE": {
+    "ROOT": "한국 라디오",
+    "GROUPS": "라디오 그룹"
+  }
+}

--- a/korean_radio_alarm/index.js
+++ b/korean_radio_alarm/index.js
@@ -1,0 +1,1922 @@
+'use strict';
+
+var fs = require('fs-extra');
+var path = require('path');
+var libQ = require('kew');
+var cron = require('node-cron');
+var childProcess = require('child_process');
+var VConf = require('v-conf');
+var https = require('https');
+
+var AlarmHelpers = require('./lib/alarm');
+
+var PLUGIN_NAME = 'korean_radio_alarm';
+var SOURCE_ID = 'korean_radio_alarm';
+var SOURCE_URI = AlarmHelpers.SOURCE_URI || 'korean_radio_alarm://';
+var STATION_URI_PREFIX = AlarmHelpers.STATION_URI_PREFIX || (SOURCE_URI + 'station/');
+var BROWSE_SOURCE_NAME = 'Korean Radio Alarm';
+var WEBRADIO_SERVICE = 'webradio';
+var KBS_PLAY_API_URL_BASE = 'https://static.api.kbs.co.kr/play/1.2/live/channel/';
+var KBS_PLAY_API_AUTHORIZATION = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJwbGF0Zm9ybUlkIjoia2JzLWhvbWUiLCJ1c2VySWQiOiIiLCJkYXRhIjoiIiwic2NvcGUiOlsiZGVmYXVsdCIsImFkbWluIl0sInRva2VuRXhwaXJlVGltZSI6MjIyNDkxMTMwODIwM30.hb4K_Wn2ekzNO84xfAOrPnj2OyAeRt7HgSr2TzgQvJQ';
+var STREAM_RESOLVER_CACHE_TTL_MS = 20 * 60 * 1000;
+var WEEKDAY_KEYS = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];
+var ALARM_DEFAULT_ACTION = 'play';
+var ALARM_SLOT_ID_REGEXP = /^alarm_(\d+)$/;
+var ALARM_SLOT_FIELD_REGEXP = /^alarm_(\d+)_(.+)$/;
+
+function KoreanRadioAlarm(context) {
+  this.context = context;
+  this.commandRouter = this.context.coreCommand;
+  this.logger = this.context && this.context.logger ? this.context.logger : {
+    info: function () {},
+    error: function () {}
+  };
+  this.configManager = this.context.configManager || new VConf();
+
+  this.configFile = null;
+  this.catalogFile = path.join(__dirname, 'radio_stations.json');
+  this.catalog = { groups: [] };
+
+  this.pluginName = PLUGIN_NAME;
+  this.scheduledJobs = [];
+  this._streamResolverCache = {};
+  this._streamResolverInFlight = {};
+  this.alarmConfig = null;
+  this.i18n = null;
+  this.mpdPlugin = null;
+  this.timezone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+}
+
+function safePromise(fn) {
+  var defer = libQ.defer();
+  var promise;
+
+  try {
+    promise = fn();
+
+    if (promise && typeof promise.then === 'function') {
+      promise.then(function (value) {
+        defer.resolve(value);
+      }).catch ? promise.catch(function (err) {
+        defer.reject(err);
+      }) : promise.fail(function (err) {
+        defer.reject(err);
+      });
+    } else {
+      defer.resolve(promise);
+    }
+  } catch (e) {
+    defer.reject(e);
+  }
+
+  return defer.promise;
+}
+
+function callPluginMethod(context, methodName, args) {
+  var defer = libQ.defer();
+  var fn = context && context[methodName];
+
+  if (typeof fn !== 'function') {
+    defer.resolve(false);
+    return defer.promise;
+  }
+
+  var consumed = false;
+  var callbackCount = fn.length;
+
+  try {
+    if (callbackCount > (args ? args.length : 0)) {
+      var cb = function (err, result) {
+        if (consumed) {
+          return;
+        }
+        consumed = true;
+        if (err) {
+          defer.reject(err);
+        } else {
+          defer.resolve(result);
+        }
+      };
+
+      var invocationArgs = (args || []).concat([cb]);
+      var ret = fn.apply(context, invocationArgs);
+      if (ret && typeof ret.then === 'function') {
+        if (typeof ret.catch === 'function') {
+          ret.then(function (value) {
+            if (!consumed) {
+              consumed = true;
+              defer.resolve(value);
+            }
+          }).catch(function (err) {
+            if (!consumed) {
+              consumed = true;
+              defer.reject(err);
+            }
+          });
+        } else {
+          ret.then(function (value) {
+            if (!consumed) {
+              consumed = true;
+              defer.resolve(value);
+            }
+          }).fail(function (err) {
+            if (!consumed) {
+              consumed = true;
+              defer.reject(err);
+            }
+          });
+        }
+      }
+    } else {
+      var value = fn.apply(context, args || []);
+      if (value && typeof value.then === 'function') {
+        if (typeof value.catch === 'function') {
+          value.then(function (result) {
+            defer.resolve(result);
+          }).catch(function (err) {
+            defer.reject(err);
+          });
+        } else {
+          value.then(function (result) {
+            defer.resolve(result);
+          }).fail(function (err) {
+            defer.reject(err);
+          });
+        }
+      } else {
+        defer.resolve(value);
+      }
+    }
+  } catch (e) {
+    defer.reject(e);
+  }
+
+  return defer.promise;
+}
+
+function toLabel(value, width) {
+  var str = String(value);
+  while (str.length < width) {
+    str = '0' + str;
+  }
+  return str;
+}
+
+function stripSlotIdPrefix(fieldId) {
+  var match = ALARM_SLOT_FIELD_REGEXP.exec(fieldId);
+  return match ? match[1] : '';
+}
+
+function alarmSlotLabelFor(slotId) {
+  var numberPart = parseInt((slotId || '').split('_')[1], 10);
+  if (!isNaN(numberPart) && numberPart >= 1 && numberPart <= 3) {
+    return 'TRANSLATE.SECTION.ALARM_SLOT_' + numberPart;
+  }
+
+  return 'TRANSLATE.SECTION.ALARM_SLOT';
+}
+
+function buildAlarmSection(slotId, slotIndex, alarmConfig, stationOptions, hourOptions, minuteOptions, volumeOptions) {
+  var keys = alarmSlotConfigKeys(slotId);
+  var actionOptions = [
+    { value: 'play', label: 'TRANSLATE.ALARM.ACTION_PLAY' },
+    { value: 'stop', label: 'TRANSLATE.ALARM.ACTION_STOP' }
+  ];
+
+  return {
+    id: 'alarm_settings_' + slotIndex,
+    element: 'section',
+    label: alarmSlotLabelFor(slotId),
+    icon: 'fa-clock-o',
+    onSave: {
+      type: 'controller',
+      endpoint: 'music_service/korean_radio_alarm',
+      method: 'saveAlarm'
+    },
+    saveButton: {
+      label: 'TRANSLATE.BUTTON.SAVE',
+      data: [keys.enabled, keys.action, keys.hour, keys.minute, keys.station, keys.volume, keys.monday, keys.tuesday, keys.wednesday, keys.thursday, keys.friday, keys.saturday, keys.sunday]
+    },
+    content: [
+      { type: 'boolean', element: 'switch', id: keys.enabled, label: 'TRANSLATE.ALARM.ENABLED', value: !!alarmConfig.alarm_enabled },
+      {
+        element: 'select',
+        id: keys.action,
+        label: 'TRANSLATE.ALARM.ACTION',
+        value: alarmConfig.alarm_action || ALARM_DEFAULT_ACTION,
+        options: actionOptions
+      },
+      { element: 'select', id: keys.hour, label: 'TRANSLATE.ALARM.HOUR', value: alarmConfig.alarm_hour, options: hourOptions },
+      { element: 'select', id: keys.minute, label: 'TRANSLATE.ALARM.MINUTE', value: alarmConfig.alarm_minute, options: minuteOptions },
+      { element: 'select', id: keys.station, label: 'TRANSLATE.ALARM.STATION', value: alarmConfig.alarm_station_uri, options: stationOptions },
+      { element: 'select', id: keys.volume, label: 'TRANSLATE.ALARM.VOLUME', value: alarmConfig.alarm_volume, options: volumeOptions },
+      { type: 'boolean', element: 'switch', id: keys.monday, label: 'TRANSLATE.WEEKDAY.MONDAY', value: !!alarmConfig.monday },
+      { type: 'boolean', element: 'switch', id: keys.tuesday, label: 'TRANSLATE.WEEKDAY.TUESDAY', value: !!alarmConfig.tuesday },
+      { type: 'boolean', element: 'switch', id: keys.wednesday, label: 'TRANSLATE.WEEKDAY.WEDNESDAY', value: !!alarmConfig.wednesday },
+      { type: 'boolean', element: 'switch', id: keys.thursday, label: 'TRANSLATE.WEEKDAY.THURSDAY', value: !!alarmConfig.thursday },
+      { type: 'boolean', element: 'switch', id: keys.friday, label: 'TRANSLATE.WEEKDAY.FRIDAY', value: !!alarmConfig.friday },
+      { type: 'boolean', element: 'switch', id: keys.saturday, label: 'TRANSLATE.WEEKDAY.SATURDAY', value: !!alarmConfig.saturday },
+      { type: 'boolean', element: 'switch', id: keys.sunday, label: 'TRANSLATE.WEEKDAY.SUNDAY', value: !!alarmConfig.sunday },
+      {
+        element: 'button',
+        id: slotId + '_delete',
+        label: 'TRANSLATE.BUTTON.DELETE_ALARM',
+        onClick: {
+          type: 'emit',
+          message: 'callMethod',
+          data: {
+            endpoint: 'music_service/korean_radio_alarm',
+            method: 'deleteAlarm',
+            data: {
+              slotId: slotId
+            }
+          }
+        }
+      }
+    ]
+  };
+}
+
+function streamResolverCacheKey(resolverType, channelId) {
+  return resolverType + ':' + channelId;
+}
+
+function getSlotIdForKey(key) {
+  var match = ALARM_SLOT_FIELD_REGEXP.exec(key);
+  if (!match) {
+    return null;
+  }
+  return 'alarm_' + match[1];
+}
+
+function isLegacyAlarmKey(key) {
+  return key === 'alarm_enabled' || key === 'alarm_hour' || key === 'alarm_minute' || key === 'alarm_station_uri' || key === 'alarm_volume' || key === 'monday' || key === 'tuesday' || key === 'wednesday' || key === 'thursday' || key === 'friday' || key === 'saturday' || key === 'sunday';
+}
+
+function defaultAlarmConfig(alarmSlot, catalog) {
+  var defaultStation = AlarmHelpers.firstStationUriFromCatalog(catalog) || '';
+  return {
+    alarm_enabled: false,
+    alarm_action: ALARM_DEFAULT_ACTION,
+    alarm_hour: 7,
+    alarm_minute: 0,
+    alarm_station_uri: defaultStation,
+    alarm_volume: 45,
+    monday: true,
+    tuesday: true,
+    wednesday: true,
+    thursday: true,
+    friday: true,
+    saturday: false,
+    sunday: false
+  };
+}
+
+function defaultAlarmConfigForMigration(slotId, catalog) {
+  var defaults = defaultAlarmConfig(slotId, catalog);
+  if (slotId === 'alarm_1') {
+    return defaults;
+  }
+
+  return {
+    alarm_enabled: false,
+    alarm_action: ALARM_DEFAULT_ACTION,
+    alarm_hour: defaults.alarm_hour,
+    alarm_minute: defaults.alarm_minute,
+    alarm_station_uri: defaults.alarm_station_uri,
+    alarm_volume: defaults.alarm_volume,
+    monday: false,
+    tuesday: false,
+    wednesday: false,
+    thursday: false,
+    friday: false,
+    saturday: false,
+    sunday: false
+  };
+}
+
+function normalizeAlarmSlotId(slotId) {
+  var candidate = String(slotId || '').trim();
+  var match = ALARM_SLOT_ID_REGEXP.exec(candidate);
+  if (match) {
+    return 'alarm_' + match[1];
+  }
+
+  if (/^\d+$/.test(candidate)) {
+    return 'alarm_' + parseInt(candidate, 10);
+  }
+
+  return null;
+}
+
+function buildActionValue(value) {
+  var action = typeof value === 'string' ? value : (value === null || value === undefined ? '' : String(value));
+  if (action === 'play' || action === 'stop') {
+    return action;
+  }
+  return ALARM_DEFAULT_ACTION;
+}
+
+function parseAlarmIds(value) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  if (value === null || value === undefined) {
+    return [];
+  }
+
+  var valueAsString = String(value).trim();
+  if (valueAsString.length === 0) {
+    return [];
+  }
+
+  return valueAsString.split(',').map(function (part) {
+    return part.trim();
+  }).filter(function (part) {
+    return part.length > 0;
+  });
+}
+
+function normalizeAlarmSlotIds(values) {
+  var dedup = {};
+  var normalized = [];
+
+  (values || []).forEach(function (value) {
+    var slotId = normalizeAlarmSlotId(value);
+    if (!slotId) {
+      return;
+    }
+
+    if (dedup[slotId]) {
+      return;
+    }
+
+    dedup[slotId] = true;
+    normalized.push(slotId);
+  });
+
+  normalized.sort(function (a, b) {
+    var aNum = parseInt(a.split('_')[1], 10);
+    var bNum = parseInt(b.split('_')[1], 10);
+    return aNum - bNum;
+  });
+
+  return normalized;
+}
+
+function alarmSlotConfigKeys(slotId) {
+  return {
+    enabled: slotId + '_enabled',
+    action: slotId + '_action',
+    hour: slotId + '_hour',
+    minute: slotId + '_minute',
+    station: slotId + '_station_uri',
+    volume: slotId + '_volume',
+    monday: slotId + '_monday',
+    tuesday: slotId + '_tuesday',
+    wednesday: slotId + '_wednesday',
+    thursday: slotId + '_thursday',
+    friday: slotId + '_friday',
+    saturday: slotId + '_saturday',
+    sunday: slotId + '_sunday'
+  };
+}
+
+function readJsonOrDefault(filePath, fallback) {
+  try {
+    if (fs.existsSync(filePath)) {
+      return fs.readJsonSync(filePath);
+    }
+  } catch (e) {
+    return fallback;
+  }
+
+  return fallback;
+}
+
+function resolveLanguageCode(commandRouter) {
+  var sharedVars = commandRouter && commandRouter.sharedVars ? commandRouter.sharedVars : null;
+  if (sharedVars) {
+    var sharedLanguage;
+    if (typeof sharedVars.get === 'function') {
+      sharedLanguage = sharedVars.get('language_code');
+    } else if (typeof sharedVars.language_code === 'string') {
+      sharedLanguage = sharedVars.language_code;
+    }
+
+    if (typeof sharedLanguage === 'string' && sharedLanguage.length > 0) {
+      return sharedLanguage;
+    }
+  }
+
+  var lang = commandRouter && commandRouter.getLanguage ? commandRouter.getLanguage() : null;
+  if (typeof lang === 'string' && lang.length > 0) {
+    return lang;
+  }
+
+  return 'en';
+}
+
+function addBrowseSource(context, source) {
+  if (!context) {
+    return null;
+  }
+
+  if (typeof context.addToBrowseSources === 'function') {
+    return context.addToBrowseSources(source);
+  }
+
+  if (typeof context.volumioAddToBrowseSources === 'function') {
+    return context.volumioAddToBrowseSources(source);
+  }
+
+  return null;
+}
+
+function removeBrowseSource(context, sourceUri) {
+  if (!context) {
+    return null;
+  }
+
+  if (typeof context.removeBrowseSource === 'function') {
+    return context.removeBrowseSource(sourceUri);
+  }
+
+  if (typeof context.volumioRemoveBrowseSource === 'function') {
+    return context.volumioRemoveBrowseSource(sourceUri);
+  }
+
+  if (typeof context.volumioRemoveBrowseSources === 'function') {
+    return context.volumioRemoveBrowseSources(sourceUri);
+  }
+
+  if (typeof context.removeFromBrowseSources === 'function') {
+    return context.removeFromBrowseSources(sourceUri);
+  }
+
+  return null;
+}
+
+KoreanRadioAlarm.prototype.onVolumioStart = function () {
+  var configFile = null;
+
+  if (this.commandRouter && this.commandRouter.pluginManager && typeof this.commandRouter.pluginManager.getConfigurationFile === 'function') {
+    configFile = this.commandRouter.pluginManager.getConfigurationFile(this.context, 'config.json');
+  }
+
+  this.configFile = configFile || path.join(__dirname, 'config.json');
+  this.configManager = new VConf();
+  this.configManager.loadFile(this.configFile);
+
+  this._loadCatalog();
+  return libQ.resolve();
+};
+
+KoreanRadioAlarm.prototype.onStart = function () {
+  var self = this;
+
+  this._loadCatalog();
+
+  return this._loadI18n()
+    .then(function () {
+      if (self.commandRouter && self.commandRouter.pluginManager && typeof self.commandRouter.pluginManager.getPlugin === 'function') {
+        self.mpdPlugin = self.commandRouter.pluginManager.getPlugin('music_service', 'mpd');
+      }
+
+      self._addBrowseSource();
+      self._rescheduleAlarm();
+      safePromise(function () {
+        return self._warmUpStreamResolverCache();
+      }).fail(function (err) {
+        if (self.logger && typeof self.logger.error === 'function') {
+          var message = err && err.message ? err.message : 'Unknown error';
+          self.logger.error('KBS stream resolver warm-up failed: ' + message);
+        }
+      });
+    });
+};
+
+KoreanRadioAlarm.prototype.onStop = function () {
+  this._clearScheduledJobs();
+  this._removeBrowseSource();
+  return libQ.resolve();
+};
+
+KoreanRadioAlarm.prototype.getConfigurationFiles = function () {
+  return ['config.json'];
+};
+
+KoreanRadioAlarm.prototype.getUIConfig = function () {
+  var self = this;
+  var lang = resolveLanguageCode(this.commandRouter);
+
+  return safePromise(function () {
+    if (!self.commandRouter || typeof self.commandRouter.i18nJson !== 'function') {
+      return readJsonOrDefault(path.join(__dirname, 'UIConfig.json'), {});
+    }
+
+    var requested = path.join(__dirname, 'i18n', 'strings_' + lang + '.json');
+    var fallback = path.join(__dirname, 'i18n', 'strings_en.json');
+    return self.commandRouter.i18nJson(requested, fallback, path.join(__dirname, 'UIConfig.json'));
+  }).then(function (uiConfig) {
+    if (!uiConfig || !uiConfig.sections || !Array.isArray(uiConfig.sections)) {
+      return uiConfig;
+    }
+
+    var alarmIds = self._getStoredAlarmIds();
+    var stationOptions = AlarmHelpers.stationOptionsFromCatalog(self.catalog);
+    var hourOptions = [];
+    for (var h = 0; h <= 23; h++) {
+      hourOptions.push({ value: h, label: toLabel(h, 2) });
+    }
+
+    var minuteOptions = [];
+    for (var m = 0; m <= 59; m++) {
+      minuteOptions.push({ value: m, label: toLabel(m, 2) });
+    }
+
+    var volumeOptions = [];
+    for (var v = 0; v <= 100; v += 5) {
+      volumeOptions.push({ value: v, label: String(v) });
+    }
+
+    var builtSections = [];
+    uiConfig.sections.forEach(function (section) {
+      if (!section) {
+        return;
+      }
+
+      if (section.id === 'alarm_actions') {
+        builtSections.push(section);
+      }
+    });
+
+    alarmIds.forEach(function (slotId, index) {
+      var alarmConfig = self._getStoredAlarmConfig(slotId);
+      builtSections.push(buildAlarmSection(slotId, index + 1, alarmConfig, stationOptions, hourOptions, minuteOptions, volumeOptions));
+    });
+
+    uiConfig.sections = builtSections;
+    return uiConfig;
+  });
+};
+
+KoreanRadioAlarm.prototype.saveAlarm = function (data) {
+  var self = this;
+  data = data || {};
+  if (data.value && typeof data.value === 'object') {
+    data = data.value;
+  }
+
+  var slotId = this._extractSlotIdFromPayload(data);
+  if (!slotId) {
+    slotId = 'alarm_1';
+  }
+
+  var storedAlarmIds = this._getStoredAlarmIds();
+
+  var prefix = slotId + '_';
+  var existing = this._getStoredAlarmConfig(slotId);
+  var useLegacyPayload = slotId === 'alarm_1' &&
+    (Object.prototype.hasOwnProperty.call(data, 'alarm_enabled') ||
+      Object.prototype.hasOwnProperty.call(data, 'alarm_hour') ||
+      Object.prototype.hasOwnProperty.call(data, 'alarm_minute') ||
+      Object.prototype.hasOwnProperty.call(data, 'alarm_station_uri') ||
+      Object.prototype.hasOwnProperty.call(data, 'alarm_volume') ||
+      Object.prototype.hasOwnProperty.call(data, 'monday') ||
+      Object.prototype.hasOwnProperty.call(data, 'tuesday') ||
+      Object.prototype.hasOwnProperty.call(data, 'wednesday') ||
+      Object.prototype.hasOwnProperty.call(data, 'thursday') ||
+      Object.prototype.hasOwnProperty.call(data, 'friday') ||
+      Object.prototype.hasOwnProperty.call(data, 'saturday') ||
+      Object.prototype.hasOwnProperty.call(data, 'sunday'));
+
+  var stationUri = this._normalizeStationValue(useLegacyPayload ? data.alarm_station_uri : data[prefix + 'station_uri']);
+  var station = stationUri ? AlarmHelpers.findStationByUri(this.catalog, stationUri) : null;
+
+  var setEnabled = Object.prototype.hasOwnProperty.call(data, prefix + 'enabled') ||
+    (useLegacyPayload && Object.prototype.hasOwnProperty.call(data, 'alarm_enabled'));
+  var setHour = Object.prototype.hasOwnProperty.call(data, prefix + 'hour') ||
+    (useLegacyPayload && Object.prototype.hasOwnProperty.call(data, 'alarm_hour'));
+  var setMinute = Object.prototype.hasOwnProperty.call(data, prefix + 'minute') ||
+    (useLegacyPayload && Object.prototype.hasOwnProperty.call(data, 'alarm_minute'));
+  var setVolume = Object.prototype.hasOwnProperty.call(data, prefix + 'volume') ||
+    (useLegacyPayload && Object.prototype.hasOwnProperty.call(data, 'alarm_volume'));
+  var setStation = Object.prototype.hasOwnProperty.call(data, prefix + 'station_uri') ||
+    (useLegacyPayload && Object.prototype.hasOwnProperty.call(data, 'alarm_station_uri'));
+  var setAction = Object.prototype.hasOwnProperty.call(data, prefix + 'action');
+
+  var enabled = this._normalizeBooleanValue(setEnabled ? (useLegacyPayload ? data.alarm_enabled : data[prefix + 'enabled']) : existing.alarm_enabled);
+  var hour = AlarmHelpers.normalizeSelectValue(setHour ? (useLegacyPayload ? data.alarm_hour : data[prefix + 'hour']) : existing.alarm_hour, 0, 23, 1, existing.alarm_hour);
+  var minute = AlarmHelpers.normalizeSelectValue(setMinute ? (useLegacyPayload ? data.alarm_minute : data[prefix + 'minute']) : existing.alarm_minute, 0, 59, 1, existing.alarm_minute);
+  var volume = AlarmHelpers.normalizeSelectValue(setVolume ? (useLegacyPayload ? data.alarm_volume : data[prefix + 'volume']) : existing.alarm_volume, 0, 100, 5, existing.alarm_volume);
+  var action = buildActionValue(setAction ? data[prefix + 'action'] : existing.alarm_action);
+  var weekdays = this._getWeekdayValuesFromPayload(slotId, data, existing);
+
+  if (!station) {
+    station = { uri: existing.alarm_station_uri };
+    if (setStation) {
+      var noStation = this._t('ALARM.NO_STATION', 'No valid station');
+      this._pushToast('error', this._t('ALARM.TITLE', 'Korean Radio Alarm'), noStation);
+      return libQ.reject(new Error(noStation));
+    }
+  }
+
+  if ((setHour || setMinute || setEnabled || setVolume || setStation) && (!AlarmHelpers.isValidTime(hour, minute) || volume === null)) {
+    var msg = this._t('ALARM.SAVE_ERROR', this._t('ALARM.SAVE_ERROR', 'Failed to save alarm settings'));
+    this._pushToast('error', this._t('ALARM.TITLE', 'Korean Radio Alarm'), msg);
+    return libQ.reject(new Error(msg));
+  }
+
+  if (storedAlarmIds.indexOf(slotId) === -1) {
+    this._saveAlarmIdList(storedAlarmIds.concat([slotId]));
+  }
+
+  if (setEnabled) {
+    this.configManager.set(prefix + 'enabled', !!enabled);
+  }
+  if (setHour) {
+    this.configManager.set(prefix + 'hour', hour);
+  }
+  if (setMinute) {
+    this.configManager.set(prefix + 'minute', minute);
+  }
+  if (setVolume) {
+    this.configManager.set(prefix + 'volume', volume);
+  }
+  if (setAction) {
+    this.configManager.set(prefix + 'action', action);
+  }
+  if (setStation) {
+    this.configManager.set(prefix + 'station_uri', station.uri || stationUri);
+  }
+
+  WEEKDAY_KEYS.forEach(function (weekday) {
+    var field = prefix + weekday;
+    var legacyField = weekday;
+
+    if (Object.prototype.hasOwnProperty.call(data, field)) {
+      self.configManager.set(field, self._normalizeBooleanValue(data[field]));
+      return;
+    }
+
+    if (slotId === 'alarm_1' && Object.prototype.hasOwnProperty.call(data, legacyField)) {
+      self.configManager.set(field, self._normalizeBooleanValue(data[legacyField]));
+    }
+  });
+
+  this._persistConfig();
+  this.alarmConfig = this._getStoredAlarmConfig(slotId);
+  this._rescheduleAlarm();
+  this._pushToast('success', this._t('ALARM.TITLE', 'Korean Radio Alarm'), this._t('ALARM.SAVE_SUCCESS', 'Alarm settings saved and rescheduled'));
+
+  return libQ.resolve({
+    success: true,
+    slot: slotId,
+    alarm: this.alarmConfig
+  });
+};
+
+KoreanRadioAlarm.prototype.addAlarm = function () {
+  var slotIds = this._getStoredAlarmIds();
+  var nextSlotId = this._getNextAvailableAlarmId(slotIds);
+  var slotConfig = defaultAlarmConfig(nextSlotId, this.catalog);
+  var keys = alarmSlotConfigKeys(nextSlotId);
+
+  this.configManager.set(keys.enabled, this._normalizeBooleanValue(slotConfig.alarm_enabled));
+  this.configManager.set(keys.action, slotConfig.alarm_action);
+  this.configManager.set(keys.hour, slotConfig.alarm_hour);
+  this.configManager.set(keys.minute, slotConfig.alarm_minute);
+  this.configManager.set(keys.station, slotConfig.alarm_station_uri);
+  this.configManager.set(keys.volume, slotConfig.alarm_volume);
+  this.configManager.set(keys.monday, this._normalizeBooleanValue(slotConfig.monday));
+  this.configManager.set(keys.tuesday, this._normalizeBooleanValue(slotConfig.tuesday));
+  this.configManager.set(keys.wednesday, this._normalizeBooleanValue(slotConfig.wednesday));
+  this.configManager.set(keys.thursday, this._normalizeBooleanValue(slotConfig.thursday));
+  this.configManager.set(keys.friday, this._normalizeBooleanValue(slotConfig.friday));
+  this.configManager.set(keys.saturday, this._normalizeBooleanValue(slotConfig.saturday));
+  this.configManager.set(keys.sunday, this._normalizeBooleanValue(slotConfig.sunday));
+
+  this._saveAlarmIdList(slotIds.concat([nextSlotId]));
+  this._persistConfig();
+  this._rescheduleAlarm();
+  this._pushToast('success', this._t('ALARM.TITLE', 'Korean Radio Alarm'), this._t('ALARM.ADD_SUCCESS', 'Alarm added successfully'));
+
+  return libQ.resolve({
+    success: true,
+    slot: nextSlotId,
+    alarmIds: this._getStoredAlarmIds()
+  });
+};
+
+KoreanRadioAlarm.prototype.deleteAlarm = function (data) {
+  data = data || {};
+  var slotId = this._extractSlotIdFromPayload(data);
+  if (!slotId) {
+    var missing = this._t('ALARM.DELETE_MISSING_SLOT', 'No slot provided');
+    this._pushToast('error', this._t('ALARM.TITLE', 'Korean Radio Alarm'), missing);
+    return libQ.reject(new Error(missing));
+ }
+
+  var alarmIds = this._getStoredAlarmIds().filter(function (value) {
+    return value !== slotId;
+  });
+  this._saveAlarmIdList(alarmIds);
+
+  var keys = alarmSlotConfigKeys(slotId);
+  if (typeof this.configManager.delete === 'function') {
+    Object.keys(keys).forEach(function (key) {
+      this.configManager.delete(keys[key]);
+    }, this);
+  } else {
+    this._setDefaultConfigForSlot(slotId);
+  }
+
+  this._persistConfig();
+  this._rescheduleAlarm();
+  this._pushToast('success', this._t('ALARM.TITLE', 'Korean Radio Alarm'), this._t('ALARM.DELETE_SUCCESS', 'Alarm deleted successfully'));
+
+  return libQ.resolve({
+    success: true,
+    slot: slotId,
+    alarmIds: alarmIds
+  });
+};
+
+KoreanRadioAlarm.prototype.explodeUri = function (uri) {
+  var station = AlarmHelpers.findStationByUri(this.catalog, uri);
+  if (!station) {
+    return libQ.reject(new Error('Invalid uri'));
+  }
+
+  return this._resolveStationStreamUrl(station).then(function (resolvedStreamUrl) {
+    var stationUri = station.uri || (STATION_URI_PREFIX + station.id);
+    var track = {
+      service: 'mpd',
+      type: 'track',
+      stationUri: stationUri,
+      trackType: 'webradio',
+      duration: 0,
+      isStreaming: true,
+      album: station.name,
+      artist: station.name,
+      uri: resolvedStreamUrl,
+      realUri: resolvedStreamUrl,
+      path: resolvedStreamUrl,
+      name: station.name,
+      title: station.name
+    };
+
+    return [track];
+  });
+};
+
+KoreanRadioAlarm.prototype.handleBrowseUri = function (uri) {
+  uri = uri || SOURCE_URI;
+
+  if (uri === SOURCE_URI) {
+    return this._buildRootNavigation();
+  }
+
+  if (uri.indexOf(SOURCE_URI + 'group/') === 0) {
+    var groupId = decodeURIComponent(uri.substring((SOURCE_URI + 'group/').length));
+    return this._buildGroupNavigation(groupId);
+  }
+
+  return this._buildRootNavigation();
+};
+
+KoreanRadioAlarm.prototype._stopPlayback = function () {
+  var self = this;
+  var stopPromise = null;
+
+  if (this.mpdPlugin && typeof this.mpdPlugin.sendMpdCommand === 'function') {
+    stopPromise = callPluginMethod(this.mpdPlugin, 'sendMpdCommand', ['stop', []]);
+  } else if (this.commandRouter) {
+    if (typeof this.commandRouter.volumioStop === 'function') {
+      stopPromise = callPluginMethod(this.commandRouter, 'volumioStop', []);
+    } else if (typeof this.commandRouter.stop === 'function') {
+      stopPromise = callPluginMethod(this.commandRouter, 'stop', []);
+    } else {
+      stopPromise = libQ.resolve(false);
+    }
+  } else {
+    stopPromise = libQ.resolve(false);
+  }
+
+  return stopPromise.then(function () {
+    if (!self.commandRouter || !self.commandRouter.stateMachine || typeof self.commandRouter.stateMachine.syncState !== 'function') {
+      return libQ.resolve();
+    }
+
+    var currentState = {
+      service: 'mpd',
+      status: 'stop',
+      title: '',
+      album: '',
+      artist: '',
+      uri: '',
+      path: '',
+      trackType: 'webradio',
+      isStreaming: false,
+      duration: 0,
+      stationUri: '',
+      pluginUri: ''
+    };
+
+    if (!self.mpdPlugin || typeof self.mpdPlugin.getState !== 'function') {
+      return callPluginMethod(self.commandRouter.stateMachine, 'syncState', [currentState, 'mpd']);
+    }
+
+    return callPluginMethod(self.mpdPlugin, 'getState', [])
+      .then(function (state) {
+        if (!state) {
+          state = currentState;
+        } else {
+          currentState.service = state.service || currentState.service;
+          currentState.status = state.status || currentState.status;
+          currentState.uri = state.uri || currentState.uri;
+          currentState.path = state.path || currentState.path;
+          currentState.title = state.title || currentState.title;
+          currentState.trackType = state.trackType || currentState.trackType;
+          currentState.duration = typeof state.duration === 'number' ? state.duration : currentState.duration;
+          currentState.album = state.album || currentState.album;
+          currentState.artist = state.artist || currentState.artist;
+          if (state.stationUri) {
+            currentState.stationUri = state.stationUri;
+          }
+          if (state.pluginUri) {
+            currentState.pluginUri = state.pluginUri;
+          }
+
+          currentState.status = 'stop';
+          currentState.isStreaming = false;
+
+          return currentState;
+        }
+
+        return currentState;
+      })
+      .fail(function () {
+        return currentState;
+      })
+      .then(function (state) {
+        state.status = 'stop';
+        state.isStreaming = false;
+        return callPluginMethod(self.commandRouter.stateMachine, 'syncState', [state, state.service || 'mpd']);
+      });
+  });
+};
+
+KoreanRadioAlarm.prototype.clearAddPlayTrack = function (track) {
+  if (!this.mpdPlugin) {
+    var noMpd = this._t('ALARM.NO_MPD', 'MPD is unavailable');
+    this._pushToast('error', this._t('ALARM.TITLE', 'Korean Radio Alarm'), noMpd);
+    return libQ.reject(new Error(noMpd));
+  }
+
+  var playTrack = track;
+  if (!playTrack || typeof playTrack !== 'object') {
+    return libQ.reject(new Error(this._t('ALARM.NO_URI', 'No track URI')));
+  }
+
+  var hasUri = typeof playTrack.uri === 'string' && playTrack.uri.length > 0;
+  var hasRealUri = typeof playTrack.realUri === 'string' && playTrack.realUri.length > 0;
+
+  if (!hasUri && !hasRealUri) {
+    return libQ.reject(new Error(this._t('ALARM.NO_URI', 'No track URI')));
+  }
+
+  var self = this;
+  var serviceName = typeof playTrack.service === 'string' && playTrack.service.length > 0 ? playTrack.service : PLUGIN_NAME;
+  var syncService = serviceName === PLUGIN_NAME || serviceName === WEBRADIO_SERVICE ? 'mpd' : serviceName;
+
+  return self._preparePlayTrackForPlayback(playTrack)
+    .then(function (preparedTrack) {
+      playTrack = preparedTrack;
+
+      if (!playTrack.realUri) {
+        playTrack.realUri = playTrack.uri;
+      }
+
+      return callPluginMethod(self.mpdPlugin, 'sendMpdCommand', ['stop', []]);
+    })
+    .then(function () {
+      return callPluginMethod(self.mpdPlugin, 'sendMpdCommand', ['clear', []]);
+    })
+    .then(function () {
+      return callPluginMethod(self.mpdPlugin, 'sendMpdCommand', ['add "' + playTrack.realUri + '"', []]);
+    })
+    .then(function () {
+      return callPluginMethod(self.mpdPlugin, 'sendMpdCommand', ['play', []]);
+    })
+    .then(function () {
+      if (!self.commandRouter.stateMachine || typeof self.commandRouter.stateMachine.syncState !== 'function') {
+        return true;
+      }
+
+      if (typeof self.mpdPlugin.getState !== 'function') {
+        return true;
+      }
+
+      return callPluginMethod(self.mpdPlugin, 'getState', []).then(function (state) {
+        if (!state) {
+          return true;
+        }
+
+        state.service = syncService;
+        state.title = playTrack.name || playTrack.title || state.title;
+        if (syncService === 'mpd') {
+          state.uri = playTrack.realUri || playTrack.uri || state.uri;
+        } else {
+          state.uri = playTrack.uri || playTrack.realUri || state.uri;
+        }
+        state.path = playTrack.realUri || playTrack.path || state.path;
+        state.trackType = playTrack.trackType || 'webradio';
+        state.isStreaming = playTrack.isStreaming !== undefined ? playTrack.isStreaming : true;
+        state.duration = typeof playTrack.duration === 'number' ? playTrack.duration : 0;
+        if (playTrack.stationUri) {
+          state.stationUri = playTrack.stationUri;
+        } else if (playTrack.pluginUri) {
+          state.stationUri = playTrack.pluginUri;
+        } else if (typeof playTrack.uri === 'string' && playTrack.uri.indexOf(SOURCE_URI) === 0) {
+          state.stationUri = playTrack.uri;
+        }
+
+        if (playTrack.pluginUri) {
+          state.pluginUri = playTrack.pluginUri;
+        } else if (playTrack.stationUri) {
+          state.pluginUri = playTrack.stationUri;
+        }
+        if (!state.album) {
+          state.album = playTrack.album || playTrack.name;
+        }
+        if (!state.artist) {
+          state.artist = playTrack.artist || playTrack.name;
+        }
+
+        return callPluginMethod(self.commandRouter.stateMachine, 'syncState', [state, syncService]);
+      });
+    });
+};
+
+KoreanRadioAlarm.prototype._preparePlayTrackForPlayback = function (track) {
+  var self = this;
+
+  if (!track) {
+    return libQ.reject(new Error(this._t('ALARM.NO_URI', 'No track URI')));
+  }
+
+  var hasUri = typeof track.uri === 'string' && track.uri.length > 0;
+  var hasRealUri = typeof track.realUri === 'string' && track.realUri.length > 0;
+
+  if (!hasUri && !hasRealUri) {
+    return libQ.reject(new Error(this._t('ALARM.NO_URI', 'No track URI')));
+  }
+
+  var shouldResolve = typeof track.uri === 'string' &&
+    track.uri.indexOf(STATION_URI_PREFIX) === 0 &&
+    (!hasRealUri || track.realUri === track.uri);
+
+  if (!shouldResolve) {
+    return libQ.resolve(track);
+  }
+
+  var station = AlarmHelpers.findStationByUri(this.catalog, track.uri);
+  if (!station) {
+    return libQ.resolve(track);
+  }
+
+  return this._resolveStationStreamUrl(station).then(function (resolvedStreamUrl) {
+    track.realUri = resolvedStreamUrl;
+    track.path = resolvedStreamUrl;
+    return track;
+  });
+};
+
+KoreanRadioAlarm.prototype._onAlarmFire = function (slotId) {
+  var self = this;
+  var alarmConfig = this._getStoredAlarmConfig(slotId || 'alarm_1');
+  if (!alarmConfig || !alarmConfig.alarm_enabled) {
+    return libQ.resolve(false);
+  }
+
+  if ((alarmConfig.alarm_action || ALARM_DEFAULT_ACTION) === 'stop') {
+    return this._stopPlayback();
+  }
+
+  var station = AlarmHelpers.findStationByUri(this.catalog, alarmConfig.alarm_station_uri);
+  if (!station) {
+    this._pushToast('error', this._t('ALARM.TITLE', 'Korean Radio Alarm'), this._t('ALARM.NO_STATION', 'No valid station'));
+    return libQ.resolve(false);
+  }
+
+  return this._setAlarmVolume(alarmConfig.alarm_volume)
+    .then(function () {
+      return self.explodeUri(station.uri || (STATION_URI_PREFIX + station.id));
+    })
+    .then(function (tracks) {
+      if (!Array.isArray(tracks) || tracks.length === 0) {
+        return libQ.reject(new Error(self._t('ALARM.NO_URI', 'No track URI')));
+      }
+      return self.clearAddPlayTrack(tracks[0]);
+    });
+};
+
+KoreanRadioAlarm.prototype._loadI18n = function () {
+  var self = this;
+  var lang = resolveLanguageCode(this.commandRouter);
+  var requested = path.join(__dirname, 'i18n', 'strings_' + lang + '.json');
+  var fallback = path.join(__dirname, 'i18n', 'strings_en.json');
+
+  var i18n = readJsonOrDefault(requested, null);
+  if (!i18n || typeof i18n !== 'object') {
+    i18n = readJsonOrDefault(fallback, {});
+  }
+
+  if (!i18n || typeof i18n !== 'object') {
+    i18n = {};
+  }
+
+  self.i18n = i18n;
+  return libQ.resolve(self.i18n);
+};
+
+KoreanRadioAlarm.prototype._t = function (path, fallback) {
+  if (!this.i18n || !path) {
+    return fallback || path;
+  }
+
+  var value = this.i18n;
+  var parts = path.split('.');
+
+  for (var i = 0; i < parts.length; i++) {
+    if (!value || typeof value !== 'object' || !(parts[i] in value)) {
+      return fallback || path;
+    }
+    value = value[parts[i]];
+  }
+
+  if (value === undefined || value === null) {
+    return fallback || path;
+  }
+
+  return value;
+};
+
+KoreanRadioAlarm.prototype._pushToast = function (type, title, message) {
+  if (!this.commandRouter || typeof this.commandRouter.pushToastMessage !== 'function') {
+    return;
+  }
+
+  this.commandRouter.pushToastMessage(type, title, message);
+};
+
+KoreanRadioAlarm.prototype._unwrapConfigValue = function (value) {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === null) {
+    return null;
+  }
+
+  if (typeof value === 'object' && value !== null && value.value !== undefined) {
+    return this._unwrapConfigValue(value.value);
+  }
+
+  return value;
+};
+
+KoreanRadioAlarm.prototype._extractSlotIdFromPayload = function (data) {
+  var directSlot = function (candidate) {
+    return normalizeAlarmSlotId(candidate || '');
+  };
+
+  if (typeof data === 'string') {
+    return directSlot(data);
+  }
+
+  var slotId = null;
+  if (data && Object.prototype.hasOwnProperty.call(data, 'slotId')) {
+    slotId = directSlot(data.slotId);
+  }
+
+  if (!slotId && data && data.value && typeof data.value === 'string') {
+    slotId = directSlot(data.value);
+  }
+
+  if (!slotId && data && data.value && typeof data.value === 'object' && !Array.isArray(data.value)) {
+    slotId = directSlot(data.value.slotId);
+  }
+
+  if (!slotId && data && data.value && typeof data.value === 'object' && !Array.isArray(data.value)) {
+    var payloadKeys = Object.keys(data.value);
+    for (var j = 0; j < payloadKeys.length; j++) {
+      var payloadKey = payloadKeys[j];
+      var valueMatch = ALARM_SLOT_FIELD_REGEXP.exec(payloadKey);
+      if (valueMatch) {
+        return 'alarm_' + valueMatch[1];
+      }
+    }
+  }
+
+  var keys = Object.keys(data || {});
+  keys.forEach(function (key) {
+    if (isLegacyAlarmKey(key)) {
+      slotId = 'alarm_1';
+      return;
+    }
+
+    var match = ALARM_SLOT_FIELD_REGEXP.exec(key);
+    if (match) {
+      slotId = 'alarm_' + match[1];
+    }
+  });
+
+  return slotId;
+};
+
+KoreanRadioAlarm.prototype._getStoredAlarmIds = function () {
+  var raw = this.configManager && typeof this.configManager.get === 'function' ? this.configManager.get('alarm_ids', undefined) : undefined;
+  var explicitAlarmIds = false;
+
+  if (this.configManager && typeof this.configManager.getKeys === 'function') {
+    try {
+      var allKeys = this.configManager.getKeys();
+      if (Array.isArray(allKeys) && allKeys.indexOf('alarm_ids') >= 0) {
+        explicitAlarmIds = true;
+      }
+    } catch (e) {}
+  } else if (raw !== undefined) {
+    explicitAlarmIds = true;
+  }
+
+  if (explicitAlarmIds) {
+    return normalizeAlarmSlotIds(parseAlarmIds(raw));
+  }
+
+  var discovered = this._discoverAlarmIdsFromKeys();
+  var meaningful = [];
+  var i;
+  for (i = 0; i < discovered.length; i++) {
+    if (discovered[i] === 'alarm_1') {
+      continue;
+    }
+
+    if (this._hasMeaningfulSlotConfigValues(discovered[i])) {
+      meaningful.push(discovered[i]);
+    }
+  }
+
+  return normalizeAlarmSlotIds(['alarm_1'].concat(meaningful));
+};
+
+KoreanRadioAlarm.prototype._discoverAlarmIdsFromKeys = function () {
+  if (!this.configManager || typeof this.configManager.getKeys !== 'function') {
+    return [];
+  }
+
+  var keys = [];
+  try {
+    keys = this.configManager.getKeys() || [];
+  } catch (e) {
+    return [];
+  }
+
+  var discovered = [];
+  var dedup = {};
+  for (var i = 0; i < keys.length; i++) {
+    var key = keys[i];
+    var match = ALARM_SLOT_FIELD_REGEXP.exec(key);
+    if (!match) {
+      continue;
+    }
+
+    var slotId = 'alarm_' + match[1];
+    if (!dedup[slotId]) {
+      dedup[slotId] = true;
+      discovered.push(slotId);
+    }
+  }
+
+  return normalizeAlarmSlotIds(discovered);
+};
+
+KoreanRadioAlarm.prototype._hasMeaningfulSlotConfigValues = function (slotId) {
+  var normalized = normalizeAlarmSlotId(slotId);
+  if (!normalized || !this.configManager || typeof this.configManager.get !== 'function') {
+    return false;
+  }
+
+  var prefix = normalized + '_';
+  var defaults = defaultAlarmConfigForMigration(normalized, this.catalog);
+  var enabled = this._unwrapConfigValue(this.configManager.get(prefix + 'enabled', defaults.alarm_enabled));
+  var action = this._unwrapConfigValue(this.configManager.get(prefix + 'action', defaults.alarm_action));
+  var hour = this._unwrapConfigValue(this.configManager.get(prefix + 'hour', defaults.alarm_hour));
+  var minute = this._unwrapConfigValue(this.configManager.get(prefix + 'minute', defaults.alarm_minute));
+  var volume = this._unwrapConfigValue(this.configManager.get(prefix + 'volume', defaults.alarm_volume));
+  var station = this._unwrapConfigValue(this.configManager.get(prefix + 'station_uri', defaults.alarm_station_uri));
+  var monday = this._unwrapConfigValue(this.configManager.get(prefix + 'monday', defaults.monday));
+  var tuesday = this._unwrapConfigValue(this.configManager.get(prefix + 'tuesday', defaults.tuesday));
+  var wednesday = this._unwrapConfigValue(this.configManager.get(prefix + 'wednesday', defaults.wednesday));
+  var thursday = this._unwrapConfigValue(this.configManager.get(prefix + 'thursday', defaults.thursday));
+  var friday = this._unwrapConfigValue(this.configManager.get(prefix + 'friday', defaults.friday));
+  var saturday = this._unwrapConfigValue(this.configManager.get(prefix + 'saturday', defaults.saturday));
+  var sunday = this._unwrapConfigValue(this.configManager.get(prefix + 'sunday', defaults.sunday));
+
+  if (!!enabled !== !!defaults.alarm_enabled) {
+    return true;
+  }
+  if (buildActionValue(action) !== defaults.alarm_action) {
+    return true;
+  }
+  if (hour !== defaults.alarm_hour || minute !== defaults.alarm_minute || volume !== defaults.alarm_volume) {
+    return true;
+  }
+  if (station !== defaults.alarm_station_uri) {
+    return true;
+  }
+
+  return !!monday !== defaults.monday ||
+    !!tuesday !== defaults.tuesday ||
+    !!wednesday !== defaults.wednesday ||
+    !!thursday !== defaults.thursday ||
+    !!friday !== defaults.friday ||
+    !!saturday !== defaults.saturday ||
+    !!sunday !== defaults.sunday;
+};
+
+KoreanRadioAlarm.prototype._getNextAvailableAlarmId = function (slotIds) {
+  var used = {};
+  for (var i = 0; i < slotIds.length; i++) {
+    used[slotIds[i]] = true;
+  }
+
+  for (var n = 1; n < 1000; n++) {
+    var candidate = 'alarm_' + n;
+    if (!used[candidate]) {
+      return candidate;
+    }
+  }
+
+  return 'alarm_1000';
+};
+
+KoreanRadioAlarm.prototype._saveAlarmIdList = function (slotIds) {
+  var sorted = normalizeAlarmSlotIds(slotIds || []);
+  if (!this.configManager || typeof this.configManager.set !== 'function') {
+    return sorted;
+  }
+
+  this.configManager.set('alarm_ids', sorted.join(','));
+  return sorted;
+};
+
+KoreanRadioAlarm.prototype._setDefaultConfigForSlot = function (slotId) {
+  var defaults = defaultAlarmConfig(slotId, this.catalog);
+  var keys = alarmSlotConfigKeys(slotId);
+  var disabledDefaults = {
+    enabled: false,
+    action: ALARM_DEFAULT_ACTION,
+    hour: 7,
+    minute: 0,
+    station_uri: defaults.alarm_station_uri,
+    volume: 45,
+    monday: false,
+    tuesday: false,
+    wednesday: false,
+    thursday: false,
+    friday: false,
+    saturday: false,
+    sunday: false
+  };
+
+  this.configManager.set(keys.enabled, disabledDefaults.enabled);
+  this.configManager.set(keys.action, disabledDefaults.action);
+  this.configManager.set(keys.hour, disabledDefaults.hour);
+  this.configManager.set(keys.minute, disabledDefaults.minute);
+  this.configManager.set(keys.station, disabledDefaults.station_uri);
+  this.configManager.set(keys.volume, disabledDefaults.volume);
+  this.configManager.set(keys.monday, disabledDefaults.monday);
+  this.configManager.set(keys.tuesday, disabledDefaults.tuesday);
+  this.configManager.set(keys.wednesday, disabledDefaults.wednesday);
+  this.configManager.set(keys.thursday, disabledDefaults.thursday);
+  this.configManager.set(keys.friday, disabledDefaults.friday);
+  this.configManager.set(keys.saturday, disabledDefaults.saturday);
+  this.configManager.set(keys.sunday, disabledDefaults.sunday);
+};
+
+KoreanRadioAlarm.prototype._getWeekdayValuesFromPayload = function (slotId, data, existing) {
+  var weekdays = {};
+  var prefix = slotId + '_';
+  var self = this;
+
+  WEEKDAY_KEYS.forEach(function (weekday) {
+    var key = prefix + weekday;
+    var legacyKey = weekday;
+
+    if (slotId === 'alarm_1' && data && Object.prototype.hasOwnProperty.call(data, legacyKey)) {
+      weekdays[weekday] = self._normalizeBooleanValue(data[legacyKey]);
+      return;
+    }
+
+    if (data && Object.prototype.hasOwnProperty.call(data, key)) {
+      weekdays[weekday] = self._normalizeBooleanValue(data[key]);
+      return;
+    }
+    weekdays[weekday] = existing[weekday];
+  }, this);
+
+  return weekdays;
+};
+
+KoreanRadioAlarm.prototype._persistConfig = function () {
+  if (!this.configManager || typeof this.configManager.save !== 'function') {
+    return;
+  }
+
+  this.configManager.save();
+};
+
+KoreanRadioAlarm.prototype._normalizeBooleanValue = function (value) {
+  value = this._unwrapConfigValue(value);
+  if (typeof value === 'string') {
+    if (value === 'false') {
+      return false;
+    }
+    if (value === 'true') {
+      return true;
+    }
+  }
+
+  return !!value;
+};
+
+KoreanRadioAlarm.prototype._normalizeStationValue = function (value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  if (typeof value === 'object') {
+    value = this._unwrapConfigValue(value);
+    if (value === null || value === undefined) {
+      return '';
+    }
+  }
+
+  return String(value);
+};
+
+KoreanRadioAlarm.prototype._hasSlotConfigValues = function (slotId) {
+  slotId = normalizeAlarmSlotId(slotId);
+  if (!slotId || !this.configManager || typeof this.configManager.get !== 'function') {
+    return false;
+  }
+  var prefix = slotId + '_';
+  return this.configManager.get(prefix + 'enabled', undefined) !== undefined ||
+    this.configManager.get(prefix + 'action', undefined) !== undefined ||
+    this.configManager.get(prefix + 'hour', undefined) !== undefined ||
+    this.configManager.get(prefix + 'minute', undefined) !== undefined ||
+    this.configManager.get(prefix + 'station_uri', undefined) !== undefined ||
+    this.configManager.get(prefix + 'volume', undefined) !== undefined ||
+    this.configManager.get(prefix + 'monday', undefined) !== undefined ||
+    this.configManager.get(prefix + 'tuesday', undefined) !== undefined ||
+    this.configManager.get(prefix + 'wednesday', undefined) !== undefined ||
+    this.configManager.get(prefix + 'thursday', undefined) !== undefined ||
+    this.configManager.get(prefix + 'friday', undefined) !== undefined ||
+    this.configManager.get(prefix + 'saturday', undefined) !== undefined ||
+    this.configManager.get(prefix + 'sunday', undefined) !== undefined;
+};
+
+KoreanRadioAlarm.prototype._hasLegacyAlarmValues = function () {
+  return this.configManager.get('alarm_enabled', undefined) !== undefined ||
+    this.configManager.get('alarm_hour', undefined) !== undefined ||
+    this.configManager.get('alarm_minute', undefined) !== undefined ||
+    this.configManager.get('alarm_station_uri', undefined) !== undefined ||
+    this.configManager.get('alarm_volume', undefined) !== undefined ||
+    this.configManager.get('monday', undefined) !== undefined ||
+    this.configManager.get('tuesday', undefined) !== undefined ||
+    this.configManager.get('wednesday', undefined) !== undefined ||
+    this.configManager.get('thursday', undefined) !== undefined ||
+    this.configManager.get('friday', undefined) !== undefined ||
+    this.configManager.get('saturday', undefined) !== undefined ||
+    this.configManager.get('sunday', undefined) !== undefined;
+};
+
+KoreanRadioAlarm.prototype._rescheduleAlarm = function () {
+  this._clearScheduledJobs();
+
+  var self = this;
+  var scheduleCount = 0;
+  var nowEnabled = [];
+  var slotIds = this._getStoredAlarmIds();
+  this.alarmConfig = {};
+
+  slotIds.forEach(function (slotId) {
+    var alarmConfig = self._getStoredAlarmConfig(slotId);
+    self.alarmConfig[slotId] = alarmConfig;
+
+    if (!alarmConfig.alarm_enabled) {
+      return;
+    }
+
+    var expressions = AlarmHelpers.buildCronExpressions(
+      alarmConfig.alarm_hour,
+      alarmConfig.alarm_minute,
+      {
+        monday: alarmConfig.monday,
+        tuesday: alarmConfig.tuesday,
+        wednesday: alarmConfig.wednesday,
+        thursday: alarmConfig.thursday,
+        friday: alarmConfig.friday,
+        saturday: alarmConfig.saturday,
+        sunday: alarmConfig.sunday
+      }
+    );
+
+    expressions.forEach(function (expr) {
+      var task = cron.schedule(expr, function () {
+        self._onAlarmFire(slotId);
+      }, {
+        timezone: self.timezone,
+        scheduled: true
+      });
+
+      self.scheduledJobs.push(task);
+      scheduleCount += 1;
+      nowEnabled.push(slotId);
+    });
+  });
+
+  return {
+    scheduled: scheduleCount,
+    enabledSlots: nowEnabled
+  };
+};
+
+KoreanRadioAlarm.prototype._clearScheduledJobs = function () {
+  if (!Array.isArray(this.scheduledJobs)) {
+    this.scheduledJobs = [];
+    return;
+  }
+
+  this.scheduledJobs.forEach(function (job) {
+    if (!job) {
+      return;
+    }
+
+    if (typeof job.stop === 'function') {
+      job.stop();
+    }
+
+    if (typeof job.destroy === 'function') {
+      job.destroy();
+    }
+  });
+
+  this.scheduledJobs = [];
+};
+
+KoreanRadioAlarm.prototype._addBrowseSource = function () {
+  if (!this.commandRouter) {
+    return;
+  }
+
+  var entry = {
+    name: this._t('ALARM.TITLE', BROWSE_SOURCE_NAME),
+    uri: SOURCE_URI,
+    plugin_name: PLUGIN_NAME,
+    plugin_type: 'music_service',
+    source: SOURCE_ID,
+    icon: 'fa-clock-o',
+    sourceicon: 'fa-clock-o',
+    albumart: '/albumart?source=' + SOURCE_ID
+  };
+
+  addBrowseSource(this.commandRouter, entry);
+};
+
+KoreanRadioAlarm.prototype._removeBrowseSource = function () {
+  if (!this.commandRouter) {
+    return;
+  }
+
+  removeBrowseSource(this.commandRouter, SOURCE_URI);
+};
+
+KoreanRadioAlarm.prototype._setAlarmVolume = function (volume) {
+  if (!Number.isInteger(volume) || volume < 0 || volume > 100) {
+    return libQ.reject(new Error(this._t('ALARM.BAD_VOLUME', 'Invalid volume')));
+  }
+
+  if (!this.commandRouter) {
+    return libQ.resolve();
+  }
+
+  if (typeof this.commandRouter.volumiosetvolume === 'function') {
+    return safePromise(function () {
+      return this.commandRouter.volumiosetvolume(volume);
+    }.bind(this));
+  }
+
+  if (typeof this.commandRouter.volumioSetVolume === 'function') {
+    return safePromise(function () {
+      return this.commandRouter.volumioSetVolume(volume);
+    }.bind(this));
+  }
+
+  var defer = libQ.defer();
+  childProcess.exec('volumio volume ' + volume, function (err) {
+    if (err) {
+      defer.reject(err);
+      return;
+    }
+    defer.resolve(true);
+  });
+  return defer.promise;
+};
+
+KoreanRadioAlarm.prototype._buildRootNavigation = function () {
+  var groups = Array.isArray(this.catalog.groups) ? this.catalog.groups : [];
+  var items = groups.map(function (group) {
+    return {
+      service: PLUGIN_NAME,
+      type: 'folder',
+      title: group.name || group.id,
+      icon: 'fa-broadcast-tower',
+      uri: SOURCE_URI + 'group/' + encodeURIComponent(group.id)
+    };
+  });
+
+  return libQ.resolve({
+    title: this._t('BROWSE.ROOT', 'Korean Radio'),
+    navigation: {
+      lists: [
+        {
+          title: this._t('BROWSE.GROUPS', 'Radio groups'),
+          icon: 'fa-broadcast-tower',
+          availableListViews: ['list'],
+          items: items
+        }
+      ],
+      prev: {
+        uri: SOURCE_URI
+      }
+    },
+    prev: {
+      uri: SOURCE_URI
+    },
+    path: SOURCE_URI,
+    isFolder: true,
+    plugin: this.pluginName
+  });
+};
+
+KoreanRadioAlarm.prototype._buildGroupNavigation = function (groupId) {
+  var groups = Array.isArray(this.catalog.groups) ? this.catalog.groups : [];
+  var target = null;
+
+  for (var i = 0; i < groups.length; i++) {
+    if (groups[i].id === groupId) {
+      target = groups[i];
+      break;
+    }
+  }
+
+  if (!target) {
+    return this._buildRootNavigation();
+  }
+
+  var stations = Array.isArray(target.stations) ? target.stations : [];
+  var items = stations.map(function (station) {
+    var streamPath = station.streamUrl || '';
+    var item = {
+      service: PLUGIN_NAME,
+      type: 'webradio',
+      stationUri: STATION_URI_PREFIX + station.id,
+      trackType: 'webradio',
+      duration: 0,
+      isStreaming: true,
+      title: station.name,
+      album: target.name || target.id,
+      artist: target.name || target.id,
+      icon: 'fa-broadcast-tower',
+      uri: station.uri || (STATION_URI_PREFIX + station.id),
+      name: station.name
+    };
+
+    if (streamPath && streamPath.length > 0) {
+      item.path = streamPath;
+      item.realUri = streamPath;
+    }
+
+    return item;
+  });
+
+  return libQ.resolve({
+    title: target.name || target.id,
+    navigation: {
+      prev: {
+        uri: SOURCE_URI
+      },
+      lists: [
+        {
+          title: target.name || target.id,
+          icon: 'fa-broadcast-tower',
+          availableListViews: ['list'],
+          items: items
+        }
+      ]
+    }
+  });
+};
+
+KoreanRadioAlarm.prototype._ensureStationUris = function () {
+  if (!this.catalog || !Array.isArray(this.catalog.groups)) {
+    return;
+  }
+
+  this.catalog.groups.forEach(function (group) {
+    if (!Array.isArray(group.stations)) {
+      return;
+    }
+
+    group.stations.forEach(function (station) {
+      if (!station.uri && station.id) {
+        station.uri = STATION_URI_PREFIX + station.id;
+      }
+    });
+  });
+};
+
+KoreanRadioAlarm.prototype._loadCatalog = function () {
+  this.catalog = readJsonOrDefault(this.catalogFile, { groups: [] });
+  this._ensureStationUris();
+};
+
+KoreanRadioAlarm.prototype._requestJson = function (url, options) {
+  var headers = options && options.headers ? options.headers : {};
+  var defer = libQ.defer();
+  var consumed = false;
+
+  var done = function (err, result) {
+    if (consumed) {
+      return;
+    }
+    consumed = true;
+    if (err) {
+      defer.reject(err);
+      return;
+    }
+    defer.resolve(result);
+  };
+
+  if (typeof url !== 'string' || !url) {
+    return libQ.reject(new Error('Missing request url'));
+  }
+
+  var req;
+  try {
+    req = https.get(url, { headers: headers }, function (res) {
+      if (res.statusCode < 200 || res.statusCode >= 300) {
+        done(new Error('KBS play api request failed with status ' + res.statusCode));
+        res.resume();
+        return;
+      }
+
+      var body = '';
+      res.setEncoding('utf8');
+      res.on('data', function (chunk) {
+        body += chunk;
+      });
+      res.on('end', function () {
+        try {
+          done(null, JSON.parse(body));
+        } catch (e) {
+          done(e);
+        }
+      });
+      res.on('error', function (err) {
+        done(err);
+      });
+    });
+  } catch (e) {
+    return done(e), defer.promise;
+  }
+
+  req.on('error', function (err) {
+    done(err);
+  });
+  req.setTimeout(10000, function () {
+    done(new Error('KBS play api request timeout'));
+    req.destroy();
+  });
+  return defer.promise;
+};
+
+KoreanRadioAlarm.prototype._getCachedResolvedStreamUrl = function (cacheKey) {
+  var cacheEntry = this._streamResolverCache[cacheKey];
+  if (!cacheEntry) {
+    return null;
+  }
+
+  if (!cacheEntry.streamUrl || cacheEntry.expiresAt <= Date.now()) {
+    delete this._streamResolverCache[cacheKey];
+    return null;
+  }
+
+  return cacheEntry.streamUrl;
+};
+
+KoreanRadioAlarm.prototype._setStreamResolverCache = function (cacheKey, streamUrl) {
+  this._streamResolverCache[cacheKey] = {
+    streamUrl: streamUrl,
+    expiresAt: Date.now() + STREAM_RESOLVER_CACHE_TTL_MS
+  };
+};
+
+KoreanRadioAlarm.prototype._warmUpStreamResolverCache = function () {
+  var self = this;
+
+  if (!self.catalog || !Array.isArray(self.catalog.groups)) {
+    return libQ.resolve();
+  }
+
+  var stationsByResolver = {};
+  self.catalog.groups.forEach(function (group) {
+    if (!group || !Array.isArray(group.stations)) {
+      return;
+    }
+
+    group.stations.forEach(function (station) {
+      if (!station || !station.streamResolver || !station.streamResolver.type) {
+        return;
+      }
+
+      var resolverType = station.streamResolver.type;
+      var channelId = station.streamResolver.channelId;
+      if (typeof resolverType !== 'string' || !resolverType.length || typeof channelId !== 'string' || !channelId.length) {
+        return;
+      }
+
+      stationsByResolver[streamResolverCacheKey(resolverType, channelId)] = station;
+    });
+  });
+
+  var warmups = [];
+  Object.keys(stationsByResolver).forEach(function (cacheKey) {
+    warmups.push(self._resolveStationStreamUrl(stationsByResolver[cacheKey]).then(function () {
+      return true;
+    }));
+  });
+
+  if (warmups.length === 0) {
+    return libQ.resolve();
+  }
+
+  return libQ.all(warmups);
+};
+
+KoreanRadioAlarm.prototype._resolveStationStreamUrl = function (station) {
+  var self = this;
+
+  if (!station) {
+    return libQ.reject(new Error('Invalid station'));
+  }
+
+  if (!station.streamResolver || !station.streamResolver.type) {
+    if (typeof station.streamUrl === 'string' && station.streamUrl.length > 0) {
+      return libQ.resolve(station.streamUrl);
+    }
+    return libQ.reject(new Error('No static stream URL for station ' + station.id));
+  }
+
+  if (station.streamResolver.type === 'kbs-play-api') {
+    var channelId = station.streamResolver.channelId;
+
+    if (typeof channelId !== 'string' || !channelId) {
+      return libQ.reject(new Error('Missing channelId for KBS play resolver on station ' + station.id));
+    }
+
+    var cacheKey = streamResolverCacheKey(station.streamResolver.type, channelId);
+    var cachedStreamUrl = self._getCachedResolvedStreamUrl(cacheKey);
+    if (cachedStreamUrl) {
+      return libQ.resolve(cachedStreamUrl);
+    }
+
+    if (self._streamResolverInFlight[cacheKey]) {
+      return self._streamResolverInFlight[cacheKey];
+    }
+
+    var endpoint = KBS_PLAY_API_URL_BASE + encodeURIComponent(channelId);
+    var headers = {
+      Authorization: KBS_PLAY_API_AUTHORIZATION
+    };
+
+    var resolvedPromise = safePromise(function () {
+      return self._requestJson(endpoint, { headers: headers });
+    }).then(function (payload) {
+      if (!payload || typeof payload.streamUrl !== 'string' || !payload.streamUrl) {
+        var invalid = new Error('Invalid KBS play api response for station ' + station.id);
+        if (self.logger && typeof self.logger.error === 'function') {
+          self.logger.error(invalid.message);
+        }
+        throw invalid;
+      }
+
+      return payload.streamUrl;
+    }).then(function (streamUrl) {
+      self._setStreamResolverCache(cacheKey, streamUrl);
+      return streamUrl;
+    }).fail(function (err) {
+      if (self.logger && typeof self.logger.error === 'function') {
+        var message = err && err.message ? err.message : 'Unknown error';
+        self.logger.error('Failed to resolve stream URL for station ' + station.id + ': ' + message);
+      }
+      throw err;
+    });
+
+    self._streamResolverInFlight[cacheKey] = resolvedPromise.then(function (streamUrl) {
+      delete self._streamResolverInFlight[cacheKey];
+      return streamUrl;
+    }, function (err) {
+      delete self._streamResolverInFlight[cacheKey];
+      throw err;
+    });
+
+    return self._streamResolverInFlight[cacheKey];
+  }
+
+  return libQ.reject(new Error('Unsupported stream resolver type ' + station.streamResolver.type + ' for station ' + station.id));
+};
+
+KoreanRadioAlarm.prototype._getStoredAlarmConfig = function (slotId) {
+  slotId = normalizeAlarmSlotId(slotId) || 'alarm_1';
+  var prefix = slotId + '_';
+  var defaultStation = AlarmHelpers.firstStationUriFromCatalog(this.catalog) || '';
+  var defaults = defaultAlarmConfig(slotId, this.catalog);
+
+  if (slotId === 'alarm_1' && !this._hasSlotConfigValues(slotId) && this._hasLegacyAlarmValues()) {
+    defaults = {
+      alarm_enabled: this._unwrapConfigValue(this.configManager.get('alarm_enabled', defaults.alarm_enabled)),
+      alarm_action: this._unwrapConfigValue(this.configManager.get('alarm_action', defaults.alarm_action)),
+      alarm_hour: this._unwrapConfigValue(this.configManager.get('alarm_hour', defaults.alarm_hour)),
+      alarm_minute: this._unwrapConfigValue(this.configManager.get('alarm_minute', defaults.alarm_minute)),
+      alarm_station_uri: this._unwrapConfigValue(this.configManager.get('alarm_station_uri', defaults.alarm_station_uri)),
+      alarm_volume: this._unwrapConfigValue(this.configManager.get('alarm_volume', defaults.alarm_volume)),
+      monday: this._unwrapConfigValue(this.configManager.get('monday', defaults.monday)),
+      tuesday: this._unwrapConfigValue(this.configManager.get('tuesday', defaults.tuesday)),
+      wednesday: this._unwrapConfigValue(this.configManager.get('wednesday', defaults.wednesday)),
+      thursday: this._unwrapConfigValue(this.configManager.get('thursday', defaults.thursday)),
+      friday: this._unwrapConfigValue(this.configManager.get('friday', defaults.friday)),
+      saturday: this._unwrapConfigValue(this.configManager.get('saturday', defaults.saturday)),
+      sunday: this._unwrapConfigValue(this.configManager.get('sunday', defaults.sunday))
+    };
+  } else {
+    defaults = {
+      alarm_enabled: this._unwrapConfigValue(this.configManager.get(prefix + 'enabled', defaults.alarm_enabled)),
+      alarm_action: this._unwrapConfigValue(this.configManager.get(prefix + 'action', defaults.alarm_action)),
+      alarm_hour: this._unwrapConfigValue(this.configManager.get(prefix + 'hour', defaults.alarm_hour)),
+      alarm_minute: this._unwrapConfigValue(this.configManager.get(prefix + 'minute', defaults.alarm_minute)),
+      alarm_station_uri: this._unwrapConfigValue(this.configManager.get(prefix + 'station_uri', defaults.alarm_station_uri)),
+      alarm_volume: this._unwrapConfigValue(this.configManager.get(prefix + 'volume', defaults.alarm_volume)),
+      monday: this._unwrapConfigValue(this.configManager.get(prefix + 'monday', defaults.monday)),
+      tuesday: this._unwrapConfigValue(this.configManager.get(prefix + 'tuesday', defaults.tuesday)),
+      wednesday: this._unwrapConfigValue(this.configManager.get(prefix + 'wednesday', defaults.wednesday)),
+      thursday: this._unwrapConfigValue(this.configManager.get(prefix + 'thursday', defaults.thursday)),
+      friday: this._unwrapConfigValue(this.configManager.get(prefix + 'friday', defaults.friday)),
+      saturday: this._unwrapConfigValue(this.configManager.get(prefix + 'saturday', defaults.saturday)),
+      sunday: this._unwrapConfigValue(this.configManager.get(prefix + 'sunday', defaults.sunday))
+    };
+  }
+
+  var stored = {
+    alarm_enabled: this._normalizeBooleanValue(defaults.alarm_enabled),
+    alarm_action: buildActionValue(defaults.alarm_action),
+    alarm_hour: AlarmHelpers.normalizeSelectValue(defaults.alarm_hour, 0, 23, 1, defaults.alarm_hour),
+    alarm_minute: AlarmHelpers.normalizeSelectValue(defaults.alarm_minute, 0, 59, 1, defaults.alarm_minute),
+    alarm_volume: AlarmHelpers.normalizeSelectValue(defaults.alarm_volume, 0, 100, 5, defaults.alarm_volume),
+    alarm_station_uri: this._normalizeStationValue(defaults.alarm_station_uri),
+    monday: this._normalizeBooleanValue(defaults.monday),
+    tuesday: this._normalizeBooleanValue(defaults.tuesday),
+    wednesday: this._normalizeBooleanValue(defaults.wednesday),
+    thursday: this._normalizeBooleanValue(defaults.thursday),
+    friday: this._normalizeBooleanValue(defaults.friday),
+    saturday: this._normalizeBooleanValue(defaults.saturday),
+    sunday: this._normalizeBooleanValue(defaults.sunday)
+  };
+
+  if (!AlarmHelpers.findStationByUri(this.catalog, stored.alarm_station_uri)) {
+    stored.alarm_station_uri = defaultStation;
+  }
+
+  return stored;
+};
+
+KoreanRadioAlarm.prototype.getBrowseList = function (uris) {
+  return this.handleBrowseUri(uris);
+};
+
+module.exports = KoreanRadioAlarm;

--- a/korean_radio_alarm/install.sh
+++ b/korean_radio_alarm/install.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR" || exit 1
+
+echo "[korean_radio_alarm] install start"
+
+echo "[korean_radio_alarm] plugin package prepared"
+echo "[korean_radio_alarm] no system writes or external dependencies required"
+
+echo plugininstallend
+exit 0

--- a/korean_radio_alarm/lib/alarm.js
+++ b/korean_radio_alarm/lib/alarm.js
@@ -1,0 +1,182 @@
+'use strict';
+
+var SOURCE_URI = 'korean_radio_alarm://';
+var STATION_URI_PREFIX = SOURCE_URI + 'station/';
+
+function toInt(value) {
+  if (value === null || value === undefined) {
+    return NaN;
+  }
+
+  if (typeof value === 'object' && value !== null && value.value !== undefined) {
+    return toInt(value.value);
+  }
+
+  if (typeof value === 'number' && isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'boolean') {
+    return NaN;
+  }
+
+  var parsed = parseInt(value, 10);
+  if (isNaN(parsed)) {
+    return NaN;
+  }
+
+  return parsed;
+}
+
+function normalizeSelectValue(value, min, max, step, fallback) {
+  var normalized = toInt(value);
+
+  if (!isFinite(normalized)) {
+    return fallback;
+  }
+
+  if (normalized < min || normalized > max) {
+    return fallback;
+  }
+
+  if (step > 0 && normalized % step !== 0) {
+    return fallback;
+  }
+
+  return normalized;
+}
+
+function isValidTime(hour, minute) {
+  return normalizeSelectValue(hour, 0, 23, 1, null) !== null &&
+    normalizeSelectValue(minute, 0, 59, 1, null) !== null;
+}
+
+function buildCronExpressions(hour, minute, weekdays) {
+  if (!isValidTime(hour, minute) || !weekdays) {
+    return [];
+  }
+
+  var minuteValue = normalizeSelectValue(minute, 0, 59, 1, null);
+  var hourValue = normalizeSelectValue(hour, 0, 23, 1, null);
+  var weekdayOrder = [
+    { key: 'monday', value: 1 },
+    { key: 'tuesday', value: 2 },
+    { key: 'wednesday', value: 3 },
+    { key: 'thursday', value: 4 },
+    { key: 'friday', value: 5 },
+    { key: 'saturday', value: 6 },
+    { key: 'sunday', value: 0 }
+  ];
+
+  var expressions = [];
+
+  for (var i = 0; i < weekdayOrder.length; i++) {
+    var entry = weekdayOrder[i];
+    if (weekdays[entry.key] === true) {
+      expressions.push('0 ' + minuteValue + ' ' + hourValue + ' * * ' + entry.value);
+    }
+  }
+
+  return expressions;
+}
+
+function stationOptionsFromCatalog(catalog) {
+  if (!catalog || !Array.isArray(catalog.groups)) {
+    return [];
+  }
+
+  var options = [];
+
+  catalog.groups.forEach(function (group) {
+    if (!group || !Array.isArray(group.stations)) {
+      return;
+    }
+
+    var groupName = group.name || group.id || '';
+
+    group.stations.forEach(function (station) {
+      if (!station || !station.id || (!station.streamUrl && !station.streamResolver)) {
+        return;
+      }
+
+      options.push({
+        value: STATION_URI_PREFIX + station.id,
+        label: groupName ? groupName + ' - ' + station.name : station.name
+      });
+    });
+  });
+
+  return options;
+}
+
+function findStationByUri(catalog, stationUri) {
+  if (!catalog || !Array.isArray(catalog.groups) || !stationUri) {
+    return null;
+  }
+
+  var target = stationUri;
+
+  if (typeof stationUri === 'object' && stationUri !== null) {
+    if (stationUri.uri) {
+      target = stationUri.uri;
+    } else if (stationUri.value) {
+      target = stationUri.value;
+    }
+  }
+
+  if (target.indexOf(STATION_URI_PREFIX) === 0) {
+    target = target.replace(STATION_URI_PREFIX, '');
+  }
+
+  for (var i = 0; i < catalog.groups.length; i++) {
+    var group = catalog.groups[i];
+    if (!group || !Array.isArray(group.stations)) {
+      continue;
+    }
+
+    for (var j = 0; j < group.stations.length; j++) {
+      var station = group.stations[j];
+      if (!station) {
+        continue;
+      }
+
+      if (station.id === target || station.uri === target || station.uri === stationUri) {
+        return station;
+      }
+
+      if (station.uri === STATION_URI_PREFIX + target || station.id === target) {
+        return station;
+      }
+    }
+  }
+
+  return null;
+}
+
+function firstStationUriFromCatalog(catalog) {
+  if (!catalog || !Array.isArray(catalog.groups)) {
+    return null;
+  }
+
+  for (var i = 0; i < catalog.groups.length; i++) {
+    var group = catalog.groups[i];
+    if (!group || !Array.isArray(group.stations) || group.stations.length === 0) {
+      continue;
+    }
+
+    return STATION_URI_PREFIX + group.stations[0].id;
+  }
+
+  return null;
+}
+
+module.exports = {
+  SOURCE_URI: SOURCE_URI,
+  STATION_URI_PREFIX: STATION_URI_PREFIX,
+  normalizeSelectValue: normalizeSelectValue,
+  isValidTime: isValidTime,
+  buildCronExpressions: buildCronExpressions,
+  stationOptionsFromCatalog: stationOptionsFromCatalog,
+  findStationByUri: findStationByUri,
+  firstStationUriFromCatalog: firstStationUriFromCatalog
+};

--- a/korean_radio_alarm/package-lock.json
+++ b/korean_radio_alarm/package-lock.json
@@ -1,0 +1,154 @@
+{
+  "name": "korean_radio_alarm",
+  "version": "0.1.4",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "korean_radio_alarm",
+      "version": "0.1.4",
+      "license": "MIT",
+      "dependencies": {
+        "fs-extra": "^11.3.0",
+        "kew": "^0.7.0",
+        "node-cron": "^4.6.0",
+        "v-conf": "^1.4.3"
+      },
+      "engines": {
+        "node": ">=20",
+        "volumio": ">=4"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+      "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/kew": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
+      "integrity": "sha512-IG6nm0+QtAMdXt9KvbgbGdvY50RSrw+U4sGZg+KlrSKPJEwVE5JVoI3d7RWfSMdBQneRheeAOj3lIjX5VL/9RQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/multimap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/multimap/-/multimap-1.0.1.tgz",
+      "integrity": "sha512-3BA0yy/HC53U1emi32s5Kk78bwDG70Hdx4TkPFSCFTNXqsDR10VoX3zJb2Kn+L6U4X929q8WChzEy2HeI7l1Bg==",
+      "license": "MIT"
+    },
+    "node_modules/node-cron": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.6.0.tgz",
+      "integrity": "sha512-Si/bzYiKRHOB8/a99T2+SDGN582ONDMSTlJr5oCkT6GtnqPjZ2s10eoQRYkW9ZHwjVxONL+W8Fb+qR0AHMQsdg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==",
+      "license": "ISC",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/v-conf": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/v-conf/-/v-conf-1.4.3.tgz",
+      "integrity": "sha512-jhnAhXDbzorq3pkoqrOzbiLP0yO4rxlfmWUvUuffDM6Dz6YZRN/LfzS1WmvJOFeq8CWapLRyO2std/U2VsOpBg==",
+      "license": "GPLV3",
+      "dependencies": {
+        "fs-extra": "^3.0.1",
+        "multimap": "1.0.1",
+        "write-file-atomic": "1.3.1"
+      }
+    },
+    "node_modules/v-conf/node_modules/fs-extra": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+      "integrity": "sha512-V3Z3WZWVUYd8hoCL5xfXJCaHWYzmtwW5XWYSlLgERi8PWd8bx1kUHUk8L1BT57e49oKnDDD180mjfrHc1yA9rg==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^3.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "node_modules/v-conf/node_modules/jsonfile": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+      "integrity": "sha512-oBko6ZHlubVB5mRFkur5vgYR1UyqX+S6Y/oCfLhqNdcc2fYFlDpIoNc7AfKS1KOGcnNAkvsr0grLck9ANM815w==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/v-conf/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/write-file-atomic": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.1.tgz",
+      "integrity": "sha512-RCTmbZJFENrUmJVmdaf3SiIDlP1YQGFub6P/WbrTxKHKLWmhnSgaM/cYsjxDwnzD0gVE2tlTUpX6Zr/9V4+DQg==",
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "slide": "^1.1.5"
+      }
+    }
+  }
+}

--- a/korean_radio_alarm/package.json
+++ b/korean_radio_alarm/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "korean_radio_alarm",
+  "version": "0.1.4",
+  "description": "Korean radio music service with a configurable weekly alarm for Volumio 4 Bookworm.",
+  "main": "index.js",
+  "author": "rightway-p",
+  "license": "MIT",
+  "keywords": [
+    "volumio",
+    "volumio plugin",
+    "korean radio",
+    "alarm",
+    "music service"
+  ],
+  "scripts": {
+    "test": "node --test test/*.test.js"
+  },
+  "engines": {
+    "node": ">=20",
+    "volumio": ">=4"
+  },
+  "volumio_info": {
+    "prettyName": "Korean Radio Alarm",
+    "plugin_type": "music_service",
+    "icon": "fa-clock-o",
+    "architectures": [
+      "amd64",
+      "armhf"
+    ],
+    "os": [
+      "bookworm"
+    ],
+    "details": "Scheduled Korean radio alarm plugin for Volumio 4 (Bookworm).",
+    "changelog": "0.1.4: add per-slot alarm action (play/stop); 0.1.3: fix dynamic alarm-slot migration, id persistence, and UI section rendering; 0.1.2: resolve KBS stream URLs through KBS play API and cache resolver results in-memory; 0.1.1: review-prep/default alarm-slot config and submission readiness updates; 0.1.0: initial release."
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rightway-p/volumio-korean-radio-alarm"
+  },
+  "homepage": "https://github.com/rightway-p/volumio-korean-radio-alarm",
+  "bugs": {
+    "url": "https://github.com/rightway-p/volumio-korean-radio-alarm/issues"
+  },
+  "dependencies": {
+    "fs-extra": "^11.3.0",
+    "kew": "^0.7.0",
+    "node-cron": "^4.6.0",
+    "v-conf": "^1.4.3"
+  }
+}

--- a/korean_radio_alarm/radio_stations.json
+++ b/korean_radio_alarm/radio_stations.json
@@ -1,0 +1,64 @@
+{
+  "groups": [
+    {
+      "id": "kbs",
+      "name": "KBS",
+      "stations": [
+        {
+          "id": "kbs-classic-fm",
+          "name": "KBS Classic FM",
+          "streamResolver": {
+            "type": "kbs-play-api",
+            "channelId": "1fm"
+          }
+        },
+        {
+          "id": "kbs-cool-fm",
+          "name": "KBS Cool FM",
+          "streamResolver": {
+            "type": "kbs-play-api",
+            "channelId": "2fm"
+          }
+        },
+        {
+          "id": "kbs-hanminjok",
+          "name": "KBS Hanminjok",
+          "streamResolver": {
+            "type": "kbs-play-api",
+            "channelId": "hanminjokradio"
+          }
+        },
+        {
+          "id": "kbs-world-radio",
+          "name": "KBS World Radio",
+          "streamResolver": {
+            "type": "kbs-play-api",
+            "channelId": "worldradio"
+          }
+        }
+      ]
+    },
+    {
+      "id": "news",
+      "name": "News",
+      "stations": [
+        {
+          "id": "ytn-radio",
+          "name": "YTN Radio",
+          "streamUrl": "https://radiolive.ytn.co.kr/radio/_definst_/20211118_fmlive/playlist.m3u8"
+        }
+      ]
+    },
+    {
+      "id": "music",
+      "name": "Music",
+      "stations": [
+        {
+          "id": "cbs-music-fm",
+          "name": "CBS Music FM",
+          "streamUrl": "https://m-aac.cbs.co.kr/cbs939/_definst_/cbs939.stream/playlist.m3u8"
+        }
+      ]
+    }
+  ]
+}

--- a/korean_radio_alarm/test/alarm.test.js
+++ b/korean_radio_alarm/test/alarm.test.js
@@ -1,0 +1,1580 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const libQ = require('kew');
+
+const {
+  normalizeSelectValue,
+  isValidTime,
+  buildCronExpressions,
+  stationOptionsFromCatalog,
+  findStationByUri,
+  STATION_URI_PREFIX,
+  SOURCE_URI
+} = require('../lib/alarm');
+
+const KoreanRadioAlarm = require('..');
+
+test('normalizeSelectValue accepts Volumio select objects', () => {
+  assert.strictEqual(normalizeSelectValue({ value: '30', label: '30' }, 0, 59, 5, null), 30);
+  assert.strictEqual(normalizeSelectValue({ value: 40 }, 0, 100, 10, null), 40);
+  assert.strictEqual(normalizeSelectValue({ value: 'invalid' }, 0, 100, 1, null), null);
+});
+
+test('isValidTime accepts 00-23 hours and 1-minute increments', () => {
+  assert.strictEqual(isValidTime(0, 0), true);
+  assert.strictEqual(isValidTime(23, 55), true);
+  assert.strictEqual(isValidTime(12, 25), true);
+  assert.strictEqual(isValidTime(12, 59), true);
+  assert.strictEqual(isValidTime(12, 60), false);
+  assert.strictEqual(isValidTime(0, -1), false);
+  assert.strictEqual(isValidTime(24, 0), false);
+});
+
+test('buildCronExpressions maps weekdays to cron entries', () => {
+  const expr = buildCronExpressions(7, 30, {
+    monday: true,
+    wednesday: true,
+    friday: false,
+    sunday: true
+  });
+
+  assert.deepStrictEqual(expr, [
+    '0 30 7 * * 1',
+    '0 30 7 * * 3',
+    '0 30 7 * * 0'
+  ]);
+});
+
+test('getUIConfig renders actions section plus dynamic stored alarms', async () => {
+  var plugin = createPlugin({
+    getLanguage: function () {
+      return 'en';
+    },
+    i18nJson: function () {
+      return require('../UIConfig.json');
+    }
+  });
+
+  var setCalls = [];
+  plugin.configManager = createConfigManager({
+    alarm_ids: 'alarm_1,alarm_2',
+    alarm_enabled: true,
+    alarm_hour: 6,
+    alarm_minute: { value: '15', type: 'number' },
+    alarm_station_uri: 'korean_radio_alarm://station/classic',
+    alarm_volume: { type: 'number', value: '50' },
+    monday: { type: 'boolean', value: false },
+    tuesday: true,
+    wednesday: false,
+    thursday: true,
+    friday: false,
+    saturday: false,
+    sunday: false,
+    alarm_2_enabled: { value: true, type: 'boolean' },
+    alarm_2_hour: { type: 'number', value: 18 },
+    alarm_2_minute: { value: 10, type: 'number' },
+    alarm_2_station_uri: 'korean_radio_alarm://station/classic',
+    alarm_2_volume: { value: 60 },
+    alarm_2_monday: { value: false },
+    alarm_2_tuesday: { value: true },
+    alarm_2_wednesday: { value: false },
+    alarm_2_thursday: { value: true },
+    alarm_2_friday: { value: false },
+    alarm_2_saturday: { value: false },
+    alarm_2_sunday: { value: false }
+  }, setCalls);
+
+  plugin.catalog = {
+    groups: [
+      {
+        id: 'kbs',
+        name: 'KBS',
+        stations: [
+          { id: 'classic', name: 'KBS Classic FM', streamUrl: 'https://example.com/stream' }
+        ]
+      }
+    ]
+  };
+
+  var ui = await plugin.getUIConfig();
+
+  assert.strictEqual(Array.isArray(ui.sections), true);
+  assert.strictEqual(ui.sections.length, 3);
+
+  var actionSection = ui.sections[0];
+  assert.strictEqual(actionSection.id, 'alarm_actions');
+  assert.strictEqual(Array.isArray(actionSection.content), true);
+  assert.strictEqual(actionSection.content.length > 0, true);
+  var addButton = actionSection.content[0];
+  assert.strictEqual(addButton.element, 'button');
+  assert.strictEqual(addButton.label, 'TRANSLATE.BUTTON.ADD_ALARM');
+  assert.strictEqual(addButton.onClick.type, 'emit');
+  assert.strictEqual(addButton.onClick.message, 'callMethod');
+  assert.strictEqual(addButton.onClick.data.endpoint, 'music_service/korean_radio_alarm');
+  assert.strictEqual(addButton.onClick.data.method, 'addAlarm');
+  assert.deepStrictEqual(addButton.onClick.data.data, {});
+
+  var section1 = ui.sections[1];
+  var section2 = ui.sections[2];
+  var slot1Hour = null;
+  var slot1Minute = null;
+  var slot1MinuteOptions = null;
+  var slot1Action = null;
+  var slot1ActionOptions = null;
+  var section2Minute = null;
+  var section2Delete = null;
+  var section1Delete = null;
+
+  for (var i = 0; i < section1.content.length; i++) {
+    var item = section1.content[i];
+    if (item.id === 'alarm_1_hour') {
+      slot1Hour = item.value;
+    }
+    if (item.id === 'alarm_1_minute') {
+      slot1Minute = item.value;
+      slot1MinuteOptions = item.options;
+    }
+    if (item.id === 'alarm_1_action') {
+      slot1Action = item.value;
+      slot1ActionOptions = item.options;
+    }
+    if (item.id === 'alarm_1_delete') {
+      section1Delete = item;
+    }
+  }
+
+  for (var x = 0; x < section2.content.length; x++) {
+    var item = section2.content[x];
+    if (item.id === 'alarm_2_minute') {
+      section2Minute = item.value;
+    }
+    if (item.id === 'alarm_2_delete') {
+      section2Delete = item;
+    }
+  }
+
+  assert.strictEqual(section1.id, 'alarm_settings_1');
+  assert.strictEqual(section2.id, 'alarm_settings_2');
+  assert.strictEqual(slot1Hour, 6);
+  assert.strictEqual(slot1Action, 'play');
+  assert.strictEqual(slot1ActionOptions.length, 2);
+  assert.deepStrictEqual(slot1ActionOptions[0].value, 'play');
+  assert.deepStrictEqual(slot1ActionOptions[1].value, 'stop');
+  assert.strictEqual(slot1Minute, 15);
+  assert.strictEqual(slot1MinuteOptions.length, 60);
+  assert.strictEqual(section2Minute, 10);
+
+  var deleteButtons = [section1Delete, section2Delete];
+  deleteButtons.forEach(function (button, index) {
+    assert.ok(button);
+    assert.strictEqual(button.element, 'button');
+    assert.strictEqual(button.label, 'TRANSLATE.BUTTON.DELETE_ALARM');
+    assert.strictEqual(button.onClick.type, 'emit');
+    assert.strictEqual(button.onClick.message, 'callMethod');
+    assert.strictEqual(button.onClick.data.endpoint, 'music_service/korean_radio_alarm');
+    assert.strictEqual(button.onClick.data.method, 'deleteAlarm');
+    assert.strictEqual(button.onClick.data.data.slotId, 'alarm_' + (index + 1));
+  });
+
+  assert.strictEqual(section1Delete.onClick.data.data.slotId, 'alarm_1');
+  assert.strictEqual(section2Delete.onClick.data.data.slotId, 'alarm_2');
+});
+
+test('fresh/default stored alarm ids only include alarm_1', async () => {
+  var plugin = createPlugin({
+    getLanguage: function () {
+      return 'en';
+    },
+    i18nJson: function () {
+      return require('../UIConfig.json');
+    }
+  });
+
+  var pluginCalls = [];
+  plugin.configManager = createConfigManager({
+    alarm_ids: 'alarm_1'
+  }, pluginCalls);
+
+  plugin.catalog = {
+    groups: [
+      {
+        id: 'kbs',
+        name: 'KBS',
+        stations: [
+          { id: 'classic', name: 'KBS Classic FM', streamUrl: 'https://example.com/stream' }
+        ]
+      }
+    ]
+  };
+
+  var ui = await plugin.getUIConfig();
+
+  assert.strictEqual(ui.sections.length, 2);
+  assert.strictEqual(ui.sections[0].id, 'alarm_actions');
+  assert.strictEqual(ui.sections[1].id, 'alarm_settings_1');
+  assert.strictEqual(ui.sections[1].content.some(function (item) {
+    return item.id === 'alarm_1_hour' && item.value === 7;
+  }), true);
+});
+
+test('explicit empty alarm_ids keeps only add action and no alarm sections', async () => {
+  var plugin = createPlugin({
+    getLanguage: function () {
+      return 'en';
+    },
+    i18nJson: function () {
+      return require('../UIConfig.json');
+    }
+  });
+
+  plugin.configManager = createConfigManager({
+    alarm_ids: '',
+    alarm_1_enabled: true,
+    alarm_1_hour: 8,
+    alarm_1_minute: 15,
+    alarm_1_station_uri: 'korean_radio_alarm://station/classic',
+    alarm_1_volume: 40,
+    alarm_1_monday: true,
+    alarm_1_tuesday: false,
+    alarm_1_wednesday: false,
+    alarm_1_thursday: false,
+    alarm_1_friday: false,
+    alarm_1_saturday: false,
+    alarm_1_sunday: false,
+    alarm_2_enabled: true,
+    alarm_2_hour: 9,
+    alarm_2_minute: 30,
+    alarm_2_station_uri: 'korean_radio_alarm://station/classic',
+    alarm_2_volume: 55,
+    alarm_2_monday: true,
+    alarm_2_tuesday: false,
+    alarm_2_wednesday: false,
+    alarm_2_thursday: false,
+    alarm_2_friday: false,
+    alarm_2_saturday: false,
+    alarm_2_sunday: false
+  });
+
+  plugin.catalog = {
+    groups: [
+      {
+        id: 'kbs',
+        name: 'KBS',
+        stations: [
+          { id: 'classic', name: 'KBS Classic FM', streamUrl: 'https://example.com/stream' }
+        ]
+      }
+    ]
+  };
+
+  var ui = await plugin.getUIConfig();
+  var storedIds = plugin._getStoredAlarmIds();
+
+  assert.deepStrictEqual(storedIds, []);
+  assert.strictEqual(ui.sections.length, 1);
+  assert.strictEqual(ui.sections[0].id, 'alarm_actions');
+});
+
+test('old fixed-slot default values do not force old unused alarms, while meaningful slots appear', async () => {
+  var plugin = createPlugin({
+    getLanguage: function () {
+      return 'en';
+    },
+    i18nJson: function () {
+      return require('../UIConfig.json');
+    }
+  });
+
+  var configData = {
+    alarm_2_enabled: false,
+    alarm_2_hour: 7,
+    alarm_2_minute: 0,
+    alarm_2_station_uri: 'korean_radio_alarm://station/classic',
+    alarm_2_volume: 45,
+    alarm_2_monday: false,
+    alarm_2_tuesday: false,
+    alarm_2_wednesday: false,
+    alarm_2_thursday: false,
+    alarm_2_friday: false,
+    alarm_2_saturday: false,
+    alarm_2_sunday: false,
+    alarm_3_enabled: true,
+    alarm_3_hour: 8,
+    alarm_3_minute: 0,
+    alarm_3_station_uri: 'korean_radio_alarm://station/classic',
+    alarm_3_volume: 45,
+    alarm_3_monday: true,
+    alarm_3_tuesday: true,
+    alarm_3_wednesday: true,
+    alarm_3_thursday: true,
+    alarm_3_friday: true,
+    alarm_3_saturday: false,
+    alarm_3_sunday: false
+  };
+  plugin.configManager = createConfigManager(configData);
+
+  plugin.catalog = {
+    groups: [
+      {
+        id: 'kbs',
+        name: 'KBS',
+        stations: [
+          { id: 'classic', name: 'KBS Classic FM', streamUrl: 'https://example.com/stream' }
+        ]
+      }
+    ]
+  };
+
+  var ui = await plugin.getUIConfig();
+
+  assert.strictEqual(ui.sections.length, 3);
+  var slot1 = ui.sections[1];
+  var slot2 = ui.sections[2];
+
+  assert.strictEqual(slot1.id, 'alarm_settings_1');
+  assert.strictEqual(slot2.id, 'alarm_settings_2');
+
+  var hasAlarm1 = slot1.content.some(function (item) {
+    return item.id && item.id.indexOf('alarm_1_') === 0;
+  });
+  var hasAlarm2 = slot1.content.some(function (item) {
+    return item.id && item.id.indexOf('alarm_2_') === 0;
+  });
+  var slot2HasHour = slot2.content.some(function (item) {
+    return item.id === 'alarm_3_hour' && item.value === 8;
+  });
+
+  assert.strictEqual(hasAlarm1, true);
+  assert.strictEqual(hasAlarm2, false);
+  assert.strictEqual(slot2HasHour, true);
+});
+
+test('addAlarm appends next numeric slot, persists config, and reschedules', () => {
+  var setCalls = [];
+  var rescheduleCalls = [];
+  var toasts = [];
+  var plugin = createPlugin({
+    pushToastMessage: function (type, title, message) {
+      toasts.push({
+        type: type,
+        title: title,
+        message: message
+      });
+    }
+  });
+
+  plugin.configManager = createConfigManager({
+    alarm_ids: 'alarm_1',
+    alarm_1_enabled: false,
+    alarm_1_hour: 7,
+    alarm_1_minute: 0,
+    alarm_1_station_uri: 'korean_radio_alarm://station/classic',
+    alarm_1_volume: 45,
+    alarm_1_monday: true,
+    alarm_1_tuesday: true,
+    alarm_1_wednesday: true,
+    alarm_1_thursday: true,
+    alarm_1_friday: true,
+    alarm_1_saturday: false,
+    alarm_1_sunday: false
+  }, setCalls);
+
+  plugin.catalog = {
+    groups: [
+      {
+        id: 'kbs',
+        name: 'KBS',
+        stations: [
+          { id: 'classic', name: 'KBS Classic FM', streamUrl: 'https://example.com/stream' }
+        ]
+      }
+    ]
+  };
+
+  plugin._rescheduleAlarm = function () {
+    rescheduleCalls.push('called');
+    return { scheduled: 0, enabledSlots: [] };
+  };
+
+  return plugin.addAlarm().then(function (result) {
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.slot, 'alarm_2');
+    assert.deepStrictEqual(result.alarmIds, ['alarm_1', 'alarm_2']);
+    assert.deepStrictEqual(rescheduleCalls, ['called']);
+    assert.ok(setCalls.some(function (entry) {
+      return entry[0] === 'alarm_ids' && entry[1] === 'alarm_1,alarm_2';
+    }));
+    assert.ok(setCalls.some(function (entry) {
+      return entry[0] === 'alarm_2_enabled' && entry[1] === false;
+    }));
+    assert.ok(setCalls.some(function (entry) {
+      return entry[0] === 'alarm_2_action' && entry[1] === 'play';
+    }));
+    assert.strictEqual(toasts.length, 1);
+  });
+});
+
+test('saving a slot not yet in alarm_ids persists slot id and keeps slot values', () => {
+  var setCalls = [];
+  var plugin = createPlugin({});
+  var rescheduleCalls = [];
+
+  plugin.configManager = createConfigManager({
+    alarm_ids: 'alarm_1',
+    alarm_2_enabled: true,
+    alarm_2_hour: 7,
+    alarm_2_minute: 0,
+    alarm_2_station_uri: 'korean_radio_alarm://station/classic',
+    alarm_2_volume: 45,
+    alarm_2_monday: true,
+    alarm_2_tuesday: true,
+    alarm_2_wednesday: true,
+    alarm_2_thursday: true,
+    alarm_2_friday: true,
+    alarm_2_saturday: false,
+    alarm_2_sunday: false
+  }, setCalls);
+
+  plugin.catalog = {
+    groups: [
+      {
+        id: 'kbs',
+        name: 'KBS',
+        stations: [
+          { id: 'classic', name: 'KBS Classic FM', streamUrl: 'https://example.com/stream' }
+        ]
+      }
+    ]
+  };
+
+  plugin._rescheduleAlarm = function () {
+    rescheduleCalls.push('called');
+    return { scheduled: 0, enabledSlots: [] };
+  };
+
+  return plugin.saveAlarm({
+    value: {
+      alarm_2_hour: 8,
+      alarm_2_action: 'stop'
+    }
+  }).then(function (result) {
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.slot, 'alarm_2');
+    assert.deepStrictEqual(rescheduleCalls, ['called']);
+    assert.ok(setCalls.some(function (entry) {
+      return entry[0] === 'alarm_ids' && entry[1] === 'alarm_1,alarm_2';
+    }));
+    assert.ok(setCalls.some(function (entry) {
+      return entry[0] === 'alarm_2_hour' && entry[1] === 8;
+    }));
+    assert.ok(setCalls.some(function (entry) {
+      return entry[0] === 'alarm_2_action' && entry[1] === 'stop';
+    }));
+  });
+});
+
+test('deleteAlarm removes slot from storage, deletes slot config keys, and reschedules', () => {
+  var setCalls = [];
+  var deleteCalls = [];
+  var deleteArgs = [];
+  var rescheduleCalls = [];
+  var plugin = createPlugin({
+    pushToastMessage: function () {}
+  });
+
+  plugin.configManager = createConfigManager({
+    alarm_ids: 'alarm_1,alarm_2',
+    alarm_1_enabled: false,
+    alarm_1_hour: 7,
+    alarm_1_minute: 0,
+    alarm_1_station_uri: 'korean_radio_alarm://station/classic',
+    alarm_1_volume: 45,
+    alarm_1_monday: true,
+    alarm_1_tuesday: true,
+    alarm_1_wednesday: true,
+    alarm_1_thursday: true,
+    alarm_1_friday: true,
+    alarm_1_saturday: false,
+    alarm_1_sunday: false,
+    alarm_2_enabled: true,
+    alarm_2_hour: 8,
+    alarm_2_minute: 0,
+    alarm_2_station_uri: 'korean_radio_alarm://station/classic',
+    alarm_2_volume: 30,
+    alarm_2_monday: false,
+    alarm_2_tuesday: false,
+    alarm_2_wednesday: false,
+    alarm_2_thursday: false,
+    alarm_2_friday: false,
+    alarm_2_saturday: false,
+    alarm_2_sunday: false
+  }, setCalls, deleteCalls, deleteArgs);
+
+  plugin.configManager.delete = function (key) {
+    deleteArgs.push(key);
+    deleteCalls.push(key);
+  };
+
+  plugin.catalog = {
+    groups: [
+      {
+        id: 'kbs',
+        name: 'KBS',
+        stations: [
+          { id: 'classic', name: 'KBS Classic FM', streamUrl: 'https://example.com/stream' }
+        ]
+      }
+    ]
+  };
+
+  plugin._rescheduleAlarm = function () {
+    rescheduleCalls.push('called');
+    return { scheduled: 0, enabledSlots: [] };
+  };
+
+  return plugin.deleteAlarm({ value: { slotId: 'alarm_2' } }).then(function (result) {
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.slot, 'alarm_2');
+    assert.deepStrictEqual(result.alarmIds, ['alarm_1']);
+    assert.deepStrictEqual(rescheduleCalls, ['called']);
+    assert.ok(setCalls.some(function (entry) {
+      return entry[0] === 'alarm_ids' && entry[1] === 'alarm_1';
+    }));
+    var expectedDeleted = [
+      'alarm_2_enabled',
+      'alarm_2_action',
+      'alarm_2_hour',
+      'alarm_2_minute',
+      'alarm_2_station_uri',
+      'alarm_2_volume',
+      'alarm_2_monday',
+      'alarm_2_tuesday',
+      'alarm_2_wednesday',
+      'alarm_2_thursday',
+      'alarm_2_friday',
+      'alarm_2_saturday',
+      'alarm_2_sunday'
+    ];
+
+    assert.deepStrictEqual(deleteArgs.slice().sort(), expectedDeleted.slice().sort());
+  });
+});
+
+test('deleteAlarm accepts direct slot payload forms', () => {
+  var plugin = createPlugin({});
+  assert.strictEqual(plugin._extractSlotIdFromPayload('alarm_2'), 'alarm_2');
+  assert.strictEqual(plugin._extractSlotIdFromPayload({ slotId: 'alarm_3' }), 'alarm_3');
+  assert.strictEqual(plugin._extractSlotIdFromPayload({ value: { slotId: 'alarm_4' } }), 'alarm_4');
+});
+
+test('wrapped config values normalize to plain types for legacy single-alarm migration', () => {
+  var plugin = createPlugin({});
+  plugin.configManager = createConfigManager({
+    alarm_enabled: { type: 'boolean', value: true },
+    alarm_hour: { type: 'number', value: '5' },
+    alarm_minute: { type: 'number', value: '45' },
+    alarm_station_uri: { type: 'string', value: 'korean_radio_alarm://station/classic' },
+    alarm_volume: { type: 'number', value: 55 },
+    monday: { type: 'boolean', value: false },
+    tuesday: { type: 'boolean', value: true },
+    wednesday: { type: 'boolean', value: false },
+    thursday: { type: 'boolean', value: true },
+    friday: { type: 'boolean', value: false },
+    saturday: { type: 'boolean', value: false },
+    sunday: { type: 'boolean', value: true }
+  });
+
+  var stored = plugin._getStoredAlarmConfig('alarm_1');
+  assert.strictEqual(stored.alarm_enabled, true);
+  assert.strictEqual(stored.alarm_hour, 5);
+  assert.strictEqual(stored.alarm_minute, 45);
+  assert.strictEqual(stored.alarm_volume, 55);
+  assert.strictEqual(stored.alarm_station_uri, 'korean_radio_alarm://station/classic');
+  assert.strictEqual(stored.tuesday, true);
+});
+
+test('saving one slot does not overwrite config keys for other slots', async () => {
+  var calls = [];
+  var plugin = createPlugin({
+    addToBrowseSources: function () {}
+  });
+
+  plugin.configManager = createConfigManager({
+    alarm_1_enabled: true,
+    alarm_1_hour: 7,
+    alarm_1_minute: 5,
+    alarm_1_station_uri: 'korean_radio_alarm://station/classic',
+    alarm_1_volume: 40,
+    alarm_1_monday: true,
+    alarm_1_tuesday: true,
+    alarm_1_wednesday: true,
+    alarm_1_thursday: true,
+    alarm_1_friday: true,
+    alarm_1_saturday: false,
+    alarm_1_sunday: false,
+    alarm_2_enabled: true,
+    alarm_2_hour: 8,
+    alarm_2_minute: 0,
+    alarm_2_station_uri: 'korean_radio_alarm://station/classic',
+    alarm_2_volume: 30,
+    alarm_2_monday: false,
+    alarm_2_tuesday: false,
+    alarm_2_wednesday: false,
+    alarm_2_thursday: false,
+    alarm_2_friday: false,
+    alarm_2_saturday: false,
+    alarm_2_sunday: false
+  }, calls);
+
+  plugin.catalog = {
+    groups: [
+      {
+        id: 'kbs',
+        name: 'KBS',
+        stations: [
+          { id: 'classic', name: 'KBS Classic FM', streamUrl: 'https://example.com/stream' }
+        ]
+      }
+    ]
+  };
+  plugin.mpdPlugin = {
+    sendMpdCommand: function () {},
+    getState: function () {
+      return Promise.resolve({});
+    }
+  };
+  plugin._rescheduleAlarm = function () {
+    return {
+      scheduled: 0,
+      enabledSlots: []
+    };
+  };
+
+  await plugin.saveAlarm({
+    value: {
+      alarm_1_hour: 9
+    }
+  });
+
+  assert.ok(calls.some(function (entry) {
+    return entry[0] === 'alarm_1_hour' && entry[1] === 9;
+  }));
+
+  var touchesSlot2 = calls.some(function (entry) {
+    return entry[0].indexOf('alarm_2_') === 0;
+  });
+  assert.strictEqual(touchesSlot2, false);
+});
+
+test('legacy single-alarm values are projected to alarm_1 when slot keys do not exist', () => {
+  var plugin = createPlugin({});
+  plugin.configManager = createConfigManager({
+    alarm_enabled: true,
+    alarm_hour: 9,
+    alarm_minute: 20,
+    alarm_station_uri: 'korean_radio_alarm://station/classic',
+    alarm_volume: 35,
+    monday: true,
+    tuesday: true,
+    wednesday: false,
+    thursday: false,
+    friday: false,
+    saturday: false,
+    sunday: true
+  });
+
+  var stored = plugin._getStoredAlarmConfig('alarm_1');
+  assert.strictEqual(stored.alarm_enabled, true);
+  assert.strictEqual(stored.alarm_hour, 9);
+  assert.strictEqual(stored.alarm_minute, 20);
+  assert.strictEqual(stored.alarm_volume, 35);
+  assert.strictEqual(stored.sunday, true);
+
+  var slot3 = plugin._getStoredAlarmConfig('alarm_3');
+  assert.strictEqual(slot3.alarm_enabled, false);
+});
+
+test('rescheduleAlarm schedules every enabled slot and preserves slot context on callbacks', () => {
+  var cron = require('node-cron');
+  var originalSchedule = cron.schedule;
+    var scheduled = [];
+
+  cron.schedule = function (expr, cb, opts) {
+    scheduled.push({
+      expr: expr,
+      cb: cb,
+      opts: opts
+    });
+    return {
+      stop: function () {},
+      destroy: function () {}
+    };
+  };
+
+  try {
+    var plugin = createPlugin({});
+    plugin.configManager = createConfigManager({
+      alarm_ids: 'alarm_1,alarm_3',
+      alarm_1_enabled: true,
+      alarm_1_hour: 7,
+      alarm_1_minute: 0,
+      alarm_1_station_uri: 'korean_radio_alarm://station/classic',
+      alarm_1_volume: 45,
+      alarm_1_monday: true,
+      alarm_1_tuesday: false,
+      alarm_1_wednesday: false,
+      alarm_1_thursday: false,
+      alarm_1_friday: false,
+      alarm_1_saturday: false,
+      alarm_1_sunday: false,
+      alarm_2_enabled: true,
+      alarm_2_hour: 7,
+      alarm_2_minute: 30,
+      alarm_2_station_uri: 'korean_radio_alarm://station/classic',
+      alarm_2_volume: 45,
+      alarm_2_monday: true,
+      alarm_2_tuesday: false,
+      alarm_2_wednesday: false,
+      alarm_2_thursday: false,
+      alarm_2_friday: false,
+      alarm_2_saturday: false,
+      alarm_2_sunday: false,
+      alarm_3_enabled: true,
+      alarm_3_hour: 7,
+      alarm_3_minute: 30,
+      alarm_3_station_uri: 'korean_radio_alarm://station/classic',
+      alarm_3_volume: 45,
+      alarm_3_monday: true,
+      alarm_3_tuesday: false,
+      alarm_3_wednesday: false,
+      alarm_3_thursday: false,
+      alarm_3_friday: false,
+      alarm_3_saturday: false,
+      alarm_3_sunday: false
+    });
+
+    plugin.catalog = {
+      groups: [
+        {
+          id: 'kbs',
+          name: 'KBS',
+          stations: [
+            { id: 'classic', name: 'KBS Classic FM', streamUrl: 'https://example.com/stream' }
+          ]
+        }
+      ]
+    };
+
+    var fireLog = [];
+    plugin._onAlarmFire = function (slotId) {
+      fireLog.push(slotId);
+      return Promise.resolve(true);
+    };
+
+    plugin._rescheduleAlarm();
+    assert.strictEqual(scheduled.length, 2);
+
+    scheduled.forEach(function (task) {
+      task.cb();
+    });
+
+    assert.deepStrictEqual(
+      fireLog.slice().sort(),
+      ['alarm_1', 'alarm_3'].sort()
+    );
+  } finally {
+    cron.schedule = originalSchedule;
+  }
+});
+
+test('stationOptionsFromCatalog flattens catalog preserving group labels', () => {
+  const options = stationOptionsFromCatalog({
+    groups: [
+      {
+        id: 'kbs',
+        name: 'KBS',
+        stations: [
+          { id: 'one', name: 'KBS One', streamUrl: 'https://example.com/one', uri: STATION_URI_PREFIX + 'one' },
+          { id: 'two', name: 'KBS Two', streamUrl: 'https://example.com/two', uri: STATION_URI_PREFIX + 'two' }
+        ]
+      },
+      {
+        id: 'mbc',
+        name: 'MBC',
+        stations: [
+          { id: 'three', name: 'MBC FM', streamUrl: 'https://example.com/three', uri: STATION_URI_PREFIX + 'three' }
+        ]
+      }
+    ]
+  });
+
+  assert.deepStrictEqual(options, [
+    { value: STATION_URI_PREFIX + 'one', label: 'KBS - KBS One' },
+    { value: STATION_URI_PREFIX + 'two', label: 'KBS - KBS Two' },
+    { value: STATION_URI_PREFIX + 'three', label: 'MBC - MBC FM' }
+  ]);
+});
+
+test('radio station catalog removes unstable groups and adds KBS production-safe stations', () => {
+  var catalog = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'radio_stations.json'), 'utf8'));
+  var groupIds = catalog.groups.map(function (group) {
+    return group.id;
+  });
+
+  assert.strictEqual(groupIds.includes('mbc'), false);
+  assert.strictEqual(groupIds.includes('sbs'), false);
+  var musicGroup = catalog.groups.find(function (group) {
+    return group.id === 'music';
+  });
+  var musicStations = musicGroup && Array.isArray(musicGroup.stations) ? musicGroup.stations : [];
+  var hasListenMoe = musicStations.some(function (station) {
+    return station.id === 'listen-moe-kpop';
+  });
+  assert.strictEqual(hasListenMoe, false);
+
+  var kbs = catalog.groups.find(function (group) {
+    return group.id === 'kbs';
+  });
+  assert.strictEqual(Array.isArray(kbs.stations), true);
+
+  var hanminjok = kbs.stations.find(function (station) {
+    return station.id === 'kbs-hanminjok';
+  });
+  var classic = kbs.stations.find(function (station) {
+    return station.id === 'kbs-classic-fm';
+  });
+  var cool = kbs.stations.find(function (station) {
+    return station.id === 'kbs-cool-fm';
+  });
+  var world = kbs.stations.find(function (station) {
+    return station.id === 'kbs-world-radio';
+  });
+
+  assert.strictEqual(classic.streamResolver.type, 'kbs-play-api');
+  assert.strictEqual(classic.streamResolver.channelId, '1fm');
+  assert.strictEqual(cool.streamResolver.type, 'kbs-play-api');
+  assert.strictEqual(cool.streamResolver.channelId, '2fm');
+  assert.strictEqual(hanminjok.name, 'KBS Hanminjok');
+  assert.strictEqual(hanminjok.streamResolver.type, 'kbs-play-api');
+  assert.strictEqual(hanminjok.streamResolver.channelId, 'hanminjokradio');
+  assert.strictEqual(world.streamResolver.type, 'kbs-play-api');
+  assert.strictEqual(world.streamResolver.channelId, 'worldradio');
+});
+
+function createPlugin(coreCommand) {
+  var plugin = new KoreanRadioAlarm({
+    coreCommand: coreCommand || {},
+    logger: { info: function () {}, error: function () {} }
+  });
+
+  plugin.catalog = {
+    groups: [
+      {
+        id: 'kbs',
+        name: 'KBS',
+        stations: [
+          { id: 'classic', name: 'KBS Classic FM', streamUrl: 'https://example.com/stream' }
+        ]
+      }
+    ]
+  };
+
+  return plugin;
+}
+
+function createConfigManager(values, setSpy, deleteSpy) {
+  var store = values || {};
+  var deleteCalls = deleteSpy || [];
+  return {
+    get: function (key, fallback) {
+      if (Object.prototype.hasOwnProperty.call(store, key)) {
+        return store[key];
+      }
+      return fallback;
+    },
+    set: function (key, value) {
+      setSpy && setSpy.push([key, value]);
+      store[key] = value;
+    },
+    save: function () {
+      return true;
+    },
+    getKeys: function () {
+      return Object.keys(store);
+    },
+    delete: function (key) {
+      if (deleteSpy && deleteSpy.push) {
+        deleteSpy.push(key);
+      }
+      delete store[key];
+    }
+  };
+}
+
+test('browse source registration uses addToBrowseSources when available', () => {
+  var addCalls = [];
+  var plugin = createPlugin({
+    addToBrowseSources: function (entry) {
+      addCalls.push(entry);
+    }
+  });
+
+  plugin._addBrowseSource();
+
+  assert.strictEqual(addCalls.length, 1);
+  assert.strictEqual(addCalls[0].uri, SOURCE_URI);
+  assert.strictEqual(addCalls[0].source, 'korean_radio_alarm');
+  assert.strictEqual(addCalls[0].sourceicon, 'fa-clock-o');
+  assert.strictEqual(addCalls[0].albumart, '/albumart?source=korean_radio_alarm');
+});
+
+test('browse source registration falls back to volumioAddToBrowseSources', () => {
+  var fallbackCalls = [];
+  var plugin = createPlugin({
+    volumioAddToBrowseSources: function (entry) {
+      fallbackCalls.push(entry);
+    }
+  });
+
+  plugin._addBrowseSource();
+
+  assert.strictEqual(fallbackCalls.length, 1);
+});
+
+test('onStart succeeds when i18nJson requires UIConfig path and still registers browse source', async () => {
+  var browseEntries = [];
+  var plugin = createPlugin({
+    addToBrowseSources: function (entry) {
+      browseEntries.push(entry);
+    },
+    i18nJson: function (_requested, _fallback, uiConfigPath) {
+      if (!uiConfigPath) {
+        throw new TypeError('The "path" argument must be of type string or an instance of Buffer or URL. Received undefined');
+      }
+      return {};
+    }
+  });
+
+  await plugin.onStart();
+
+  assert.strictEqual(browseEntries.length, 1);
+  assert.strictEqual(browseEntries[0].source, 'korean_radio_alarm');
+});
+
+test('onStart continues when resolver cache warm-up fails in background', async () => {
+  var browseEntries = [];
+  var warmUpCalled = false;
+  var plugin = createPlugin({
+    addToBrowseSources: function (entry) {
+      browseEntries.push(entry);
+    },
+    i18nJson: function (_requested, _fallback, uiConfigPath) {
+      if (!uiConfigPath) {
+        throw new TypeError('The "path" argument must be of type string or an instance of Buffer or URL. Received undefined');
+      }
+      return {};
+    }
+  });
+
+  plugin._warmUpStreamResolverCache = function () {
+    warmUpCalled = true;
+    return libQ.reject(new Error('warm-up request failed'));
+  };
+
+  await plugin.onStart();
+
+  assert.strictEqual(warmUpCalled, true);
+  assert.strictEqual(browseEntries.length, 1);
+  assert.strictEqual(browseEntries[0].source, 'korean_radio_alarm');
+});
+
+test('remove browse source calls compatible command router remove method', () => {
+  var removedUri;
+  var plugin = createPlugin({
+    removeBrowseSource: function (uri) {
+      removedUri = uri;
+    }
+  });
+
+  plugin._removeBrowseSource();
+
+  assert.strictEqual(removedUri, SOURCE_URI);
+});
+
+test('handleBrowseUri and explodeUri stay consistent with station option URIs', async () => {
+  var plugin = createPlugin({
+    getLanguage: function () {
+      return 'en';
+    }
+  });
+
+  var option = stationOptionsFromCatalog(plugin.catalog)[0];
+  var tracks = await plugin.explodeUri(option.value);
+  var root = await plugin.handleBrowseUri(SOURCE_URI);
+  var groupNavigation = await plugin.handleBrowseUri(SOURCE_URI + 'group/kbs');
+
+  assert.strictEqual(Array.isArray(tracks), true);
+  assert.strictEqual(tracks.length, 1);
+  assert.strictEqual(tracks[0].uri, 'https://example.com/stream');
+  assert.strictEqual(tracks[0].service, 'mpd');
+  assert.strictEqual(tracks[0].stationUri, option.value);
+  assert.strictEqual(tracks[0].trackType, 'webradio');
+  assert.strictEqual(tracks[0].duration, 0);
+  assert.strictEqual(root.navigation.prev.uri, SOURCE_URI);
+  assert.strictEqual(groupNavigation.navigation.lists[0].items[0].uri, option.value);
+  assert.strictEqual(groupNavigation.navigation.lists[0].items[0].service, 'korean_radio_alarm');
+  assert.strictEqual(groupNavigation.navigation.lists[0].items[0].type, 'webradio');
+  assert.strictEqual(groupNavigation.navigation.lists[0].items[0].trackType, 'webradio');
+  assert.strictEqual(groupNavigation.navigation.lists[0].items[0].duration, 0);
+  assert.strictEqual(groupNavigation.navigation.lists[0].items[0].realUri, 'https://example.com/stream');
+  assert.strictEqual(groupNavigation.navigation.prev.uri, SOURCE_URI);
+  assert.strictEqual(option.value, STATION_URI_PREFIX + 'classic');
+});
+
+test('explodeUri resolves dynamic streamResolver urls before playback', async () => {
+  var plugin = createPlugin({
+    getLanguage: function () {
+      return 'en';
+    }
+  });
+  plugin.catalog = {
+    groups: [
+      {
+        id: 'kbs',
+        name: 'KBS',
+        stations: [
+          {
+            id: 'world-radio',
+            name: 'KBS World Radio',
+            streamResolver: {
+              type: 'kbs-play-api',
+              channelId: 'worldradio'
+            }
+          }
+        ]
+      }
+    ]
+  };
+  plugin._ensureStationUris && plugin._ensureStationUris();
+  plugin._requestJson = function (url, options) {
+    assert.strictEqual(url, 'https://static.api.kbs.co.kr/play/1.2/live/channel/worldradio');
+    assert.strictEqual(options.headers.Authorization.length > 0, true);
+    return Promise.resolve({
+      streamUrl: 'https://kbs-world.live/playlist.m3u8'
+    });
+  };
+
+  var tracks = await plugin.explodeUri(STATION_URI_PREFIX + 'world-radio');
+  assert.strictEqual(tracks[0].service, 'mpd');
+  assert.strictEqual(tracks[0].trackType, 'webradio');
+  assert.strictEqual(tracks[0].duration, 0);
+  assert.strictEqual(tracks[0].isStreaming, true);
+  assert.strictEqual(tracks[0].album, 'KBS World Radio');
+  assert.strictEqual(tracks[0].artist, 'KBS World Radio');
+  assert.strictEqual(tracks[0].stationUri, STATION_URI_PREFIX + 'world-radio');
+  assert.strictEqual(tracks[0].uri, 'https://kbs-world.live/playlist.m3u8');
+  assert.strictEqual(tracks[0].realUri, 'https://kbs-world.live/playlist.m3u8');
+  assert.strictEqual(tracks[0].path, 'https://kbs-world.live/playlist.m3u8');
+});
+
+test('explodeUri reuses resolved stream URL for the same kbs-play-api resolver', async () => {
+  var plugin = createPlugin({
+    getLanguage: function () {
+      return 'en';
+    }
+  });
+  var requestCount = 0;
+  plugin.catalog = {
+    groups: [
+      {
+        id: 'kbs',
+        name: 'KBS',
+        stations: [
+          {
+            id: 'world-radio',
+            name: 'KBS World Radio',
+            streamResolver: {
+              type: 'kbs-play-api',
+              channelId: 'worldradio'
+            }
+          }
+        ]
+      }
+    ]
+  };
+  plugin._ensureStationUris && plugin._ensureStationUris();
+  plugin._requestJson = function (url) {
+    requestCount += 1;
+    assert.strictEqual(url, 'https://static.api.kbs.co.kr/play/1.2/live/channel/worldradio');
+    return Promise.resolve({
+      streamUrl: 'https://kbs-world.live/playlist.m3u8'
+    });
+  };
+
+  var first = await plugin.explodeUri(STATION_URI_PREFIX + 'world-radio');
+  var second = await plugin.explodeUri(STATION_URI_PREFIX + 'world-radio');
+
+  assert.strictEqual(requestCount, 1);
+  assert.strictEqual(first[0].uri, 'https://kbs-world.live/playlist.m3u8');
+  assert.strictEqual(second[0].uri, 'https://kbs-world.live/playlist.m3u8');
+  assert.strictEqual(first[0].uri, second[0].uri);
+});
+
+test('explodeUri rejects dynamic resolver payload without streamUrl', async () => {
+  var plugin = createPlugin({
+    getLanguage: function () {
+      return 'en';
+    }
+  });
+  plugin.catalog = {
+    groups: [
+      {
+        id: 'kbs',
+        name: 'KBS',
+        stations: [
+          {
+            id: 'world-radio',
+            name: 'KBS World Radio',
+            streamResolver: {
+              type: 'kbs-play-api',
+              channelId: 'worldradio'
+            }
+          }
+        ]
+      }
+    ]
+  };
+  plugin._ensureStationUris && plugin._ensureStationUris();
+  plugin._requestJson = function () {
+    return Promise.resolve({});
+  };
+
+  var captured;
+  try {
+    await plugin.explodeUri(STATION_URI_PREFIX + 'world-radio');
+    assert.fail('expected resolver payload validation to reject');
+  } catch (err) {
+    captured = err;
+  }
+
+  assert.strictEqual(captured instanceof Error, true);
+  assert.match(captured.message, /Invalid KBS play api response for station world-radio/);
+});
+
+test('findStationByUri resolves both direct ids and uri values', () => {
+  const catalog = {
+    groups: [
+      {
+        id: 'news',
+        name: 'News',
+        stations: [
+          { id: 'ytn', name: 'YTN', streamUrl: 'https://example.com/ytn', uri: STATION_URI_PREFIX + 'ytn' }
+        ]
+      }
+    ]
+  };
+
+  const byUri = findStationByUri(catalog, STATION_URI_PREFIX + 'ytn');
+  const byUriObject = findStationByUri(catalog, { value: STATION_URI_PREFIX + 'ytn', label: 'YTN' });
+  const byId = findStationByUri(catalog, 'ytn');
+  const missing = findStationByUri(catalog, 'unknown');
+
+  assert.strictEqual(byUri.name, 'YTN');
+  assert.strictEqual(byUriObject.name, 'YTN');
+  assert.strictEqual(byId.name, 'YTN');
+  assert.strictEqual(missing, null);
+});
+
+test('clearAddPlayTrack aligns stream-track metadata to mpd stateMachine.syncState', async () => {
+  var plugin = createPlugin({
+    addToBrowseSources: function () {},
+    volumioSetVolume: function () {}
+  });
+
+  var mpdCalls = [];
+  var syncStateCalls = [];
+
+  plugin.mpdPlugin = {
+    sendMpdCommand: function (command, args, cb) {
+      mpdCalls.push([command, args]);
+      if (typeof cb === 'function') {
+        cb(null, true);
+        return;
+      }
+      return Promise.resolve(true);
+    },
+    getState: function (cb) {
+      var state = {
+        status: 'playing',
+        service: 'mpd',
+        uri: 'https://old.example.com/stream',
+        title: ''
+      };
+      if (typeof cb === 'function') {
+        cb(null, state);
+        return;
+      }
+      return Promise.resolve(state);
+    }
+  };
+
+  plugin.commandRouter = {
+    stateMachine: {
+      syncState: function (state, service, cb) {
+        syncStateCalls.push([state, service]);
+        if (typeof cb === 'function') {
+          cb(null, true);
+          return;
+        }
+        return Promise.resolve(true);
+      }
+    }
+  };
+
+  await plugin.clearAddPlayTrack({
+    service: 'korean_radio_alarm',
+    uri: 'korean_radio_alarm://station/classic',
+    realUri: 'https://radio.example.com/stream',
+    name: 'KBS Classic FM'
+  });
+
+  assert.strictEqual(mpdCalls.length, 4);
+  assert.strictEqual(syncStateCalls.length, 1);
+  assert.strictEqual(syncStateCalls[0][1], 'mpd');
+  assert.strictEqual(syncStateCalls[0][0].service, 'mpd');
+  assert.strictEqual(syncStateCalls[0][0].uri, 'https://radio.example.com/stream');
+  assert.strictEqual(syncStateCalls[0][0].title, 'KBS Classic FM');
+  assert.strictEqual(syncStateCalls[0][0].path, 'https://radio.example.com/stream');
+  assert.strictEqual(syncStateCalls[0][0].stationUri, 'korean_radio_alarm://station/classic');
+  assert.strictEqual(syncStateCalls[0][0].status, 'playing');
+  assert.strictEqual(syncStateCalls[0][0].isStreaming, true);
+  assert.strictEqual(syncStateCalls[0][0].trackType, 'webradio');
+  assert.strictEqual(syncStateCalls[0][0].duration, 0);
+});
+
+test('clearAddPlayTrack resolves dynamic station uri before MPD add', async () => {
+  var plugin = createPlugin({
+    addToBrowseSources: function () {},
+    volumioSetVolume: function () {}
+  });
+
+  var mpdCalls = [];
+  var syncStateCalls = [];
+  plugin.catalog = {
+    groups: [
+      {
+        id: 'kbs',
+        name: 'KBS',
+        stations: [
+          {
+            id: 'world-radio',
+            name: 'KBS World Radio',
+            streamResolver: {
+              type: 'kbs-play-api',
+              channelId: 'worldradio'
+            }
+          }
+        ]
+      }
+    ]
+  };
+  plugin._ensureStationUris && plugin._ensureStationUris();
+  plugin._requestJson = function (url) {
+    assert.strictEqual(url, 'https://static.api.kbs.co.kr/play/1.2/live/channel/worldradio');
+    return Promise.resolve({
+      streamUrl: 'https://kbs-world.live/playlist.m3u8'
+    });
+  };
+
+  plugin.mpdPlugin = {
+    sendMpdCommand: function (command, args, cb) {
+      mpdCalls.push([command, args]);
+      if (typeof cb === 'function') {
+        cb(null, true);
+        return;
+      }
+      return Promise.resolve(true);
+    },
+    getState: function (cb) {
+      var state = {
+        status: 'playing',
+        service: 'mpd',
+        uri: 'https://old.example.com/stream',
+        title: ''
+      };
+      if (typeof cb === 'function') {
+        cb(null, state);
+        return;
+      }
+      return Promise.resolve(state);
+    }
+  };
+
+  plugin.commandRouter = {
+    stateMachine: {
+      syncState: function (state, service, cb) {
+        syncStateCalls.push([state, service]);
+        if (typeof cb === 'function') {
+          cb(null, true);
+          return;
+        }
+        return Promise.resolve(true);
+      }
+    }
+  };
+
+  await plugin.clearAddPlayTrack({
+    service: 'korean_radio_alarm',
+    uri: STATION_URI_PREFIX + 'world-radio',
+    name: 'KBS World Radio'
+  });
+
+  assert.strictEqual(mpdCalls[2][0], 'add "https://kbs-world.live/playlist.m3u8"');
+  assert.strictEqual(syncStateCalls[0][0].uri, 'https://kbs-world.live/playlist.m3u8');
+  assert.strictEqual(syncStateCalls[0][0].path, 'https://kbs-world.live/playlist.m3u8');
+  assert.strictEqual(syncStateCalls[0][0].title, 'KBS World Radio');
+  assert.strictEqual(syncStateCalls[0][0].service, 'mpd');
+  assert.strictEqual(syncStateCalls[0][0].stationUri, STATION_URI_PREFIX + 'world-radio');
+  assert.strictEqual(syncStateCalls[0][0].isStreaming, true);
+  assert.strictEqual(syncStateCalls[0][0].trackType, 'webradio');
+  assert.strictEqual(syncStateCalls[0][0].duration, 0);
+  assert.strictEqual(syncStateCalls[0][1], 'mpd');
+});
+
+test('clearAddPlayTrack uses realUri when uri is missing', async () => {
+  var plugin = createPlugin({
+    addToBrowseSources: function () {},
+    volumioSetVolume: function () {}
+  });
+
+  var mpdCalls = [];
+  var syncStateCalls = [];
+
+  plugin.mpdPlugin = {
+    sendMpdCommand: function (command, args, cb) {
+      mpdCalls.push([command, args]);
+      if (typeof cb === 'function') {
+        cb(null, true);
+        return;
+      }
+      return Promise.resolve(true);
+    },
+    getState: function (cb) {
+      var state = {
+        status: 'playing',
+        service: 'mpd',
+        uri: 'https://old.example.com/stream',
+        title: ''
+      };
+      if (typeof cb === 'function') {
+        cb(null, state);
+        return;
+      }
+      return Promise.resolve(state);
+    }
+  };
+
+  plugin.commandRouter = {
+    stateMachine: {
+      syncState: function (state, service, cb) {
+        syncStateCalls.push([state, service]);
+        if (typeof cb === 'function') {
+          cb(null, true);
+          return;
+        }
+        return Promise.resolve(true);
+      }
+    }
+  };
+
+  await plugin.clearAddPlayTrack({
+    service: 'korean_radio_alarm',
+    realUri: 'https://direct.example.com/stream',
+    name: 'Direct'
+  });
+
+  assert.strictEqual(mpdCalls[2][0], 'add "https://direct.example.com/stream"');
+  assert.strictEqual(syncStateCalls[0][0].uri, 'https://direct.example.com/stream');
+  assert.strictEqual(syncStateCalls[0][0].path, 'https://direct.example.com/stream');
+  assert.strictEqual(syncStateCalls[0][0].title, 'Direct');
+  assert.strictEqual(syncStateCalls[0][0].service, 'mpd');
+  assert.strictEqual(syncStateCalls[0][1], 'mpd');
+  assert.strictEqual(syncStateCalls[0][0].isStreaming, true);
+  assert.strictEqual(syncStateCalls[0][0].trackType, 'webradio');
+  assert.strictEqual(syncStateCalls[0][0].duration, 0);
+});
+
+test('legacy/missing action defaults to play behavior at alarm fire', async () => {
+  var plugin = createPlugin({
+    getLanguage: function () {
+      return 'en';
+    }
+  });
+  var volumeCalls = [];
+  var playCalls = [];
+
+  plugin.configManager = createConfigManager({
+    alarm_ids: 'alarm_1',
+    alarm_1_enabled: true,
+    alarm_1_hour: 7,
+    alarm_1_minute: 0,
+    alarm_1_station_uri: 'korean_radio_alarm://station/classic',
+    alarm_1_volume: 45,
+    alarm_1_monday: false,
+    alarm_1_tuesday: false,
+    alarm_1_wednesday: false,
+    alarm_1_thursday: false,
+    alarm_1_friday: false,
+    alarm_1_saturday: false,
+    alarm_1_sunday: false
+  });
+
+  plugin._setAlarmVolume = function (volume) {
+    volumeCalls.push(volume);
+    return libQ.resolve();
+  };
+  plugin.clearAddPlayTrack = function (track) {
+    playCalls.push(track.uri);
+    return libQ.resolve(true);
+  };
+
+  var result = await plugin._onAlarmFire('alarm_1');
+
+  assert.strictEqual(result, true);
+  assert.deepStrictEqual(volumeCalls, [45]);
+  assert.strictEqual(playCalls.length, 1);
+  assert.strictEqual(playCalls[0], 'https://example.com/stream');
+});
+
+test('stop action only stops playback and does not start station', async () => {
+  var plugin = createPlugin({
+    getLanguage: function () {
+      return 'en';
+    }
+  });
+  var stopCalls = 0;
+  var volumeCalls = [];
+  var playCalls = [];
+
+  plugin.configManager = createConfigManager({
+    alarm_ids: 'alarm_1',
+    alarm_1_enabled: true,
+    alarm_1_action: 'stop',
+    alarm_1_hour: 7,
+    alarm_1_minute: 0,
+    alarm_1_station_uri: 'korean_radio_alarm://station/classic',
+    alarm_1_volume: 45,
+    alarm_1_monday: false,
+    alarm_1_tuesday: false,
+    alarm_1_wednesday: false,
+    alarm_1_thursday: false,
+    alarm_1_friday: false,
+    alarm_1_saturday: false,
+    alarm_1_sunday: false
+  });
+
+  plugin._setAlarmVolume = function (volume) {
+    volumeCalls.push(volume);
+    return libQ.resolve();
+  };
+  plugin.clearAddPlayTrack = function () {
+    playCalls.push(true);
+    return libQ.resolve();
+  };
+  plugin._stopPlayback = function () {
+    stopCalls += 1;
+    return libQ.resolve(true);
+  };
+
+  var result = await plugin._onAlarmFire('alarm_1');
+
+  assert.strictEqual(result, true);
+  assert.strictEqual(stopCalls, 1);
+  assert.strictEqual(volumeCalls.length, 0);
+  assert.strictEqual(playCalls.length, 0);
+});
+
+test('_stopPlayback forces stopped state sync when mpd state is stale', async () => {
+  var plugin = createPlugin({
+    getLanguage: function () {
+      return 'en';
+    }
+  });
+
+  var sendCalls = [];
+  var syncStateCalls = [];
+
+  plugin.mpdPlugin = {
+    sendMpdCommand: function (command, args) {
+      sendCalls.push([command, args]);
+      return libQ.resolve();
+    },
+    getState: function () {
+      return libQ.resolve({
+        status: 'playing',
+        isStreaming: true,
+        service: 'mpd',
+        uri: 'https://stale.example.com/stream',
+        path: 'https://stale.example.com/stream',
+        title: 'stale title',
+        trackType: 'webradio',
+        duration: 999,
+        album: 'Korean Radio',
+        artist: 'KBS',
+        stationUri: 'korean_radio_alarm://station/classic',
+        pluginUri: 'korean_radio_alarm://station/classic'
+      });
+    }
+  };
+
+  plugin.commandRouter = {
+    stateMachine: {
+      syncState: function (state, service) {
+        syncStateCalls.push([state, service]);
+        return libQ.resolve();
+      }
+    }
+  };
+
+  await plugin._stopPlayback();
+
+  assert.strictEqual(sendCalls.length, 1);
+  assert.strictEqual(sendCalls[0][0], 'stop');
+  assert.deepStrictEqual(sendCalls[0][1], []);
+  assert.strictEqual(syncStateCalls.length, 1);
+  assert.strictEqual(syncStateCalls[0][1], 'mpd');
+  assert.strictEqual(syncStateCalls[0][0].status, 'stop');
+  assert.strictEqual(syncStateCalls[0][0].isStreaming, false);
+  assert.strictEqual(syncStateCalls[0][0].uri, 'https://stale.example.com/stream');
+});
+
+test('migrated dynamic slot action stop is treated as meaningful while play action is not', () => {
+  var plugin = createPlugin({
+    getLanguage: function () {
+      return 'en';
+    }
+  });
+
+  var migratedWithStop = createPlugin({
+    getLanguage: function () {
+      return 'en';
+    }
+  });
+
+  plugin.configManager = createConfigManager({
+    alarm_2_action: 'stop'
+  });
+  migratedWithStop.configManager = createConfigManager({
+    alarm_2_action: 'play'
+  });
+
+  var stopIds = plugin._getStoredAlarmIds();
+  var playIds = migratedWithStop._getStoredAlarmIds();
+
+  assert.deepStrictEqual(stopIds, ['alarm_1', 'alarm_2']);
+  assert.deepStrictEqual(playIds, ['alarm_1']);
+});

--- a/korean_radio_alarm/uninstall.sh
+++ b/korean_radio_alarm/uninstall.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR" || exit 1
+
+echo "[korean_radio_alarm] uninstall start"
+
+echo "[korean_radio_alarm] removing plugin registration and scheduled jobs"
+echo pluginuninstallend
+exit 0


### PR DESCRIPTION
## Summary

Adds `korean_radio_alarm`, a Volumio 4 Bookworm music service plugin for browsing Korean radio stations and scheduling radio alarms.

## Features

- Browse grouped Korean radio stations from the Volumio music library source.
- Configure dynamic alarm slots from the plugin UI.
- Each alarm slot has its own enabled state, action, time, station, volume, weekdays, and delete control.
- Alarm actions support playing a selected station or stopping playback.
- KBS dynamic stream URLs are resolved through the KBS play API and cached in memory during runtime.

## Compatibility

- Volumio: `>=4`
- Node.js: `>=20`
- OS: `bookworm`
- Architectures: `armhf`, `amd64`

## Validation

Run from `korean_radio_alarm/`:

- `npm ci --cache /tmp/npm-cache`
- `npm test` (`34` passed, `0` failed)
- JSON parse check for `package.json`, `package-lock.json`, `UIConfig.json`, `config.json`, and i18n files
- `npm pack --dry-run --cache /tmp/npm-cache`
- `git diff --check`

## Notes

The plugin source is also maintained at https://github.com/rightway-p/volumio-korean-radio-alarm.
