### PR TITLE
Flight Mode - Initial release

### DIFF
--- a/flightmode/.gitignore
+++ b/flightmode/.gitignore
@@ -1,0 +1,6 @@
+units/volumio-flightmode.path
+units/volumio-flightmode.service
+flightmode.state
+flightmode.mode
+wifi.state
+bluetooth.state

--- a/flightmode/README.md
+++ b/flightmode/README.md
@@ -1,0 +1,189 @@
+# Flight Mode
+
+Soft-blocks WiFi and Bluetooth with rfkill and keeps them blocked across reboot.
+
+The plugin holds every change it makes. Stop, disable, or uninstall releases the radios and deletes the units it created. No OS file is overwritten. Sudoers is not touched.
+
+Volumio 4 / Bookworm. `amd64` and `armhf`.
+
+## Why rfkill, not the Volumio toggles
+
+`wireless_enabled=false` is defeated by two hotspot paths in `wireless.js`. `bluetoothctl power off` is session-scoped and loses to `AutoEnable=true` at the next boot. An rfkill soft block sits below both. Nothing on a stock image fights it: the OS `volumio_rfkill_runtime` units exist but are never enabled.
+
+`boot_priority` cannot order a plugin against `wireless.service` or `bluetooth.service`. Enforcement is a systemd oneshot with `Before=` those units.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  UI["Plugin UI"] --> IDX["index.js"]
+  IDX -->|"write state / mode"| ST["wifi.state<br/>bluetooth.state<br/>flightmode.mode"]
+  IDX -->|"sudo systemctl start"| SVC["volumio-flightmode.service"]
+  PATH["volumio-flightmode.path"] -->|"rfkill change"| SVC
+  BOOT["multi-user.target"] --> SVC
+  BOOT --> PATH
+  SVC --> SH["flightmode-apply.sh"]
+  ST --> SH
+  SH -->|"type = bluetooth or wlan<br/>hard = 0 and soft ≠ desired"| SYS["/sys/class/rfkill/*/soft"]
+```
+
+The apply script is the only writer of rfkill. Node never calls `rfkill` and never writes sysfs. Privilege is the existing `/bin/systemctl`, `/bin/ln`, and `/bin/rm` NOPASSWD entries.
+
+Units are additive. `onStart` generates them in the plugin tree and `ln -sf` into `/etc/systemd/system`. `onStop` deletes those two symlinks. `/bin/cp` is not in sudoers, which is why they are symlinks.
+
+## Apply script
+
+`scripts/flightmode-apply.sh` enumerates `/sys/class/rfkill/*/type` and keeps `bluetooth` and `wlan` only. Never by index. A USB dongle does not shift the policy.
+
+| Invocation | Behaviour |
+|---|---|
+| default (oneshot / path / boot) | soft-block each type whose `*.state` is `off` |
+| `release` / `release-wifi` / `release-bluetooth` | soft-unblock those types, then reset mode to `reconcile` |
+| `--generate-path` | write the path unit and exit |
+
+`wifi.state` and `bluetooth.state` are `on` (radio allowed) or `off` (plugin holds a block). Flight mode is both `off`. An old `flightmode.state=on` migrates to both held.
+
+Writes are skipped when `hard=1`, or when `soft` is already the desired value (stops a path-unit loop).
+
+```mermaid
+flowchart TD
+  START["apply.sh"] --> GEN["Regenerate path unit from current devices"]
+  GEN --> FLAG{"--generate-path?"}
+  FLAG -->|yes| EXIT["exit"]
+  FLAG -->|no| MODE{"mode"}
+  MODE -->|release*| REL["soft = 0 on the named type(s)"]
+  REL --> RESET["mode = reconcile"]
+  MODE -->|reconcile| ON["soft = 1 on each type whose state is off"]
+  RESET --> RELOAD
+  ON --> RELOAD["daemon-reload and restart path unit<br/>only if the device set changed"]
+```
+
+Default with state `off` does not unblock. That is deliberate: a path trigger while flight mode is off must not fight an airplane key or `headless_wireless.service`. Unblock happens only on an explicit `release` (user Disable, plugin stop, uninstall).
+
+Never `rfkill unblock all`. Never write `hard`.
+
+## Airplane key
+
+`/etc/modprobe.d/rfkill_default.conf` is left alone (`master_switch_mode=2`). An x86 airplane key that unblocks all radios is undone by the path unit.
+
+```mermaid
+sequenceDiagram
+  participant Key as Airplane key
+  participant Kernel as rfkill
+  participant Path as volumio-flightmode.path
+  participant Apply as flightmode-apply.sh
+  Key->>Kernel: soft 1 to 0 on wlan / bluetooth
+  Kernel->>Path: PathChanged
+  Path->>Apply: start oneshot
+  Apply->>Apply: state is on, hard is 0
+  Apply->>Kernel: write soft 1
+```
+
+Hard block is driver-owned. The UI shows it and greys the buttons. Software cannot clear it, so no key-detection logic is required.
+
+The path unit is generated at start from the current device set, plus `PathChanged=/sys/class/rfkill` so a radio appearing later regenerates the watch list.
+
+## Lifecycle
+
+```mermaid
+stateDiagram-v2
+  [*] --> Stopped
+  Stopped --> Started: onStart
+  Started --> FlightOn: Enable
+  FlightOn --> Started: Disable
+  FlightOn --> Stopped: onStop / uninstall
+  Started --> Stopped: onStop / uninstall
+
+  state Started {
+    [*] --> UnitsLive
+    note right of UnitsLive: units enabled\nstate off\nradios not held
+  }
+  state FlightOn {
+    [*] --> RadiosHeld
+    note right of RadiosHeld: state on\nsoft block applied\npath unit re-applies
+  }
+  state Stopped {
+    [*] --> Clean
+    note right of Clean: units deleted\nradios released\nOS files untouched
+  }
+```
+
+Flight mode survives reboot only while the plugin remains enabled. That is also the recovery path: disable the plugin and the hold is gone.
+
+`uninstall.sh` repeats the same teardown as `onStop` and is idempotent. The plugin manager always calls `onStop` first.
+
+## UI
+
+One plugin page. No Save button. Three controls:
+
+- Disable / Enable WiFi
+- Disable / Enable Bluetooth
+- Disable / Enable flight mode (sets both)
+
+Flight mode on means both radios are held. Enabling one radio turns flight mode off and leaves the other held. Status, per-radio soft/hard, and whether a cable is up are filled in `getUIConfig`. Enable flight mode and disable WiFi ask for confirm (ethernet vs lockout wording). A hard block hides the buttons for that radio.
+
+Lockout is allowed. A laptop in a seat has no ethernet; that is the primary use. The confirm states that recovery is only from the local screen, or by disabling the plugin. The `wireless.js` emergency hotspot override will still run and will fail against the block. That is disclosed, not engineered away.
+
+`network/config.json` is not written. It is not this plugin’s file to restore.
+
+## What this plugin does not do
+
+- No `volumio-os` commit
+- No `sudoers.d` drop-in
+- No edit of `rfkill_default.conf`, `wireless.js`, `main.conf`, or `bluetooth.service`
+- No `has_configuration` / My Music registration
+- No System-page UI contributor (the hook exists; Network has none)
+
+## Tree
+
+```
+flightmode/
+  index.js
+  UIConfig.json
+  config.json
+  install.sh              chmod +x the apply script only
+  uninstall.sh            same teardown as onStop
+  scripts/flightmode-apply.sh
+  units/volumio-flightmode.service.in
+  units/volumio-flightmode.path.in
+  i18n/strings_{en,de,fr,it,es,nl,pl,pt,sv,da,no,fi,cz}.json
+```
+
+Generated and gitignored: `units/volumio-flightmode.service`, `units/volumio-flightmode.path`, `wifi.state`, `bluetooth.state`, `flightmode.state`, `flightmode.mode`.
+
+## Install and submit
+
+Run this on the Volumio device. `volumio plugin install` and `volumio plugin submit` are device commands. Remove `node_modules` before the commit so they are not pushed or packed.
+
+```sh
+git clone git@github.com:volumio/volumio-plugins-sources-bookworm.git --depth=1
+cd volumio-plugins-sources-bookworm
+git checkout -b flightmode
+cd flightmode
+
+# --- update code first ---
+
+volumio plugin install
+rm -Rf node_modules
+
+cd ..
+
+git add flightmode
+git commit -m 'Flight Mode - Initial release'
+git push origin flightmode
+
+cd -
+volumio plugin submit
+```
+
+`git add flightmode` only. Do not `git add *` from the repo root.
+
+## Check on device
+
+```sh
+/usr/sbin/rfkill list
+systemctl is-enabled volumio-flightmode.service volumio-flightmode.path
+ls -l /etc/systemd/system/volumio-flightmode.*
+```
+
+After disable or uninstall those two unit files must be gone and the radios unblocked.

--- a/flightmode/UIConfig.json
+++ b/flightmode/UIConfig.json
@@ -1,0 +1,152 @@
+{
+  "page": {
+    "label": "TRANSLATE.PAGE.LABEL"
+  },
+  "sections": [
+    {
+      "id": "section_status",
+      "element": "section",
+      "label": "TRANSLATE.SECTION.STATUS",
+      "icon": "fa-plane",
+      "content": [
+        {
+          "id": "status_text",
+          "element": "input",
+          "type": "text",
+          "label": "TRANSLATE.STATUS.LABEL",
+          "value": ""
+        },
+        {
+          "id": "radios_text",
+          "element": "input",
+          "type": "text",
+          "label": "TRANSLATE.RADIOS.LABEL",
+          "value": ""
+        },
+        {
+          "id": "recovery_text",
+          "element": "input",
+          "type": "text",
+          "label": "TRANSLATE.RECOVERY.LABEL",
+          "value": ""
+        }
+      ]
+    },
+    {
+      "id": "section_radios",
+      "element": "section",
+      "label": "TRANSLATE.SECTION.RADIOS",
+      "icon": "fa-wifi",
+      "content": [
+        {
+          "id": "disable_wifi",
+          "element": "button",
+          "label": "TRANSLATE.BUTTON.WIFI_DISABLE",
+          "onClick": {
+            "type": "emit",
+            "message": "callMethod",
+            "askForConfirm": {
+              "title": "TRANSLATE.CONFIRM.WIFI_TITLE",
+              "message": "TRANSLATE.CONFIRM.WIFI_NO_ETH"
+            },
+            "data": {
+              "endpoint": "system_controller/flightmode",
+              "method": "disableWifi",
+              "data": ""
+            }
+          }
+        },
+        {
+          "id": "enable_wifi",
+          "element": "button",
+          "label": "TRANSLATE.BUTTON.WIFI_ENABLE",
+          "onClick": {
+            "type": "emit",
+            "message": "callMethod",
+            "data": {
+              "endpoint": "system_controller/flightmode",
+              "method": "enableWifi",
+              "data": ""
+            }
+          }
+        },
+        {
+          "id": "disable_bluetooth",
+          "element": "button",
+          "label": "TRANSLATE.BUTTON.BT_DISABLE",
+          "onClick": {
+            "type": "emit",
+            "message": "callMethod",
+            "data": {
+              "endpoint": "system_controller/flightmode",
+              "method": "disableBluetooth",
+              "data": ""
+            }
+          }
+        },
+        {
+          "id": "enable_bluetooth",
+          "element": "button",
+          "label": "TRANSLATE.BUTTON.BT_ENABLE",
+          "onClick": {
+            "type": "emit",
+            "message": "callMethod",
+            "data": {
+              "endpoint": "system_controller/flightmode",
+              "method": "enableBluetooth",
+              "data": ""
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "section_control",
+      "element": "section",
+      "label": "TRANSLATE.SECTION.CONTROL",
+      "icon": "fa-power-off",
+      "content": [
+        {
+          "id": "enable_flightmode",
+          "element": "button",
+          "label": "TRANSLATE.BUTTON.ENABLE",
+          "onClick": {
+            "type": "emit",
+            "message": "callMethod",
+            "askForConfirm": {
+              "title": "TRANSLATE.CONFIRM.ENABLE_TITLE",
+              "message": "TRANSLATE.CONFIRM.ENABLE_NO_ETH"
+            },
+            "data": {
+              "endpoint": "system_controller/flightmode",
+              "method": "enableFlightMode",
+              "data": ""
+            }
+          }
+        },
+        {
+          "id": "disable_flightmode",
+          "element": "button",
+          "label": "TRANSLATE.BUTTON.DISABLE",
+          "onClick": {
+            "type": "emit",
+            "message": "callMethod",
+            "data": {
+              "endpoint": "system_controller/flightmode",
+              "method": "disableFlightMode",
+              "data": ""
+            }
+          }
+        },
+        {
+          "id": "hardblock_note",
+          "element": "input",
+          "type": "text",
+          "label": "TRANSLATE.STATUS.LABEL",
+          "value": "TRANSLATE.HARDBLOCK.NOTE",
+          "hidden": true
+        }
+      ]
+    }
+  ]
+}

--- a/flightmode/config.json
+++ b/flightmode/config.json
@@ -1,0 +1,10 @@
+{
+  "wifi": {
+    "type": "boolean",
+    "value": true
+  },
+  "bluetooth": {
+    "type": "boolean",
+    "value": true
+  }
+}

--- a/flightmode/i18n/strings_cz.json
+++ b/flightmode/i18n/strings_cz.json
@@ -1,0 +1,67 @@
+{
+  "PAGE": {
+    "LABEL": "Režim letadlo"
+  },
+  "SECTION": {
+    "STATUS": "Stav",
+    "RADIOS": "Rádia",
+    "CONTROL": "Režim letadlo"
+  },
+  "STATUS": {
+    "LABEL": "Stav",
+    "OFF": "Rádia zapnutá",
+    "ON": "Režim letadlo zapnutý",
+    "WIFI_OFF": "Wi-Fi vypnuté",
+    "BT_OFF": "Bluetooth vypnutý",
+    "HARD": "Hardwarový přepínač režimu letadlo je zapnutý"
+  },
+  "RADIOS": {
+    "LABEL": "Rádia",
+    "LINE": "{name} ({type}): {soft}, {hard}",
+    "NONE": "Nebyla nalezena žádná rádia Wi-Fi ani Bluetooth",
+    "WLAN": "Wi-Fi",
+    "BLUETOOTH": "Bluetooth"
+  },
+  "SOFT": {
+    "BLOCKED": "blokováno softwarem",
+    "UNBLOCKED": "neblokováno softwarem"
+  },
+  "HARD": {
+    "BLOCKED": "blokováno hardwarem",
+    "UNBLOCKED": "neblokováno hardwarem"
+  },
+  "RECOVERY": {
+    "LABEL": "Síť",
+    "ETH": "Je připojena kabelová síť. Toto zařízení zůstane dostupné přes kabel.",
+    "NO_ETH": "Žádná kabelová síť. Vypnutí Wi-Fi nebo zapnutí režimu letadlo nechá zařízení dostupné jen z této obrazovky."
+  },
+  "HARDBLOCK": {
+    "NOTE": "Hardwarový přepínač režimu letadlo vypnul rádio. To nelze zrušit softwarem."
+  },
+  "BUTTON": {
+    "ENABLE": "Zapnout režim letadlo",
+    "DISABLE": "Vypnout režim letadlo",
+    "WIFI_DISABLE": "Vypnout Wi-Fi",
+    "WIFI_ENABLE": "Zapnout Wi-Fi",
+    "BT_DISABLE": "Vypnout Bluetooth",
+    "BT_ENABLE": "Zapnout Bluetooth"
+  },
+  "CONFIRM": {
+    "ENABLE_TITLE": "Zapnout režim letadlo?",
+    "ENABLE_ETH": "Wi-Fi a Bluetooth se vypnou a zůstanou vypnuté i po restartu. Toto zařízení zůstane dostupné přes kabel.",
+    "ENABLE_NO_ETH": "Wi-Fi a Bluetooth se vypnou a zůstanou vypnuté i po restartu. Toto zařízení pak nebude dostupné po síti. Rádia lze znovu zapnout jen z této obrazovky, nebo vypnutím pluginu.",
+    "WIFI_TITLE": "Vypnout Wi-Fi?",
+    "WIFI_ETH": "Wi-Fi se vypne a zůstane vypnuté i po restartu. Toto zařízení zůstane dostupné přes kabel.",
+    "WIFI_NO_ETH": "Wi-Fi se vypne a zůstane vypnuté i po restartu. Toto zařízení pak nebude dostupné po síti. Wi-Fi lze znovu zapnout jen z této obrazovky, nebo vypnutím pluginu."
+  },
+  "TOAST": {
+    "ENABLED": "Wi-Fi a Bluetooth jsou vypnuté",
+    "DISABLED": "Wi-Fi a Bluetooth jsou zapnuté",
+    "WIFI_OFF": "Wi-Fi je vypnuté",
+    "WIFI_ON": "Wi-Fi je zapnuté",
+    "BT_OFF": "Bluetooth je vypnutý",
+    "BT_ON": "Bluetooth je zapnutý",
+    "HARD_DENIED": "Hardwarový přepínač blokuje rádio. To nelze přepsat.",
+    "FAILED": "Stav rádií se nepodařilo použít"
+  }
+}

--- a/flightmode/i18n/strings_da.json
+++ b/flightmode/i18n/strings_da.json
@@ -1,0 +1,67 @@
+{
+  "PAGE": {
+    "LABEL": "Flytilstand"
+  },
+  "SECTION": {
+    "STATUS": "Status",
+    "RADIOS": "Radioer",
+    "CONTROL": "Flytilstand"
+  },
+  "STATUS": {
+    "LABEL": "Status",
+    "OFF": "Radioer tændt",
+    "ON": "Flytilstand slået til",
+    "WIFI_OFF": "Wi-Fi slukket",
+    "BT_OFF": "Bluetooth slukket",
+    "HARD": "Den fysiske flyknap er slået til"
+  },
+  "RADIOS": {
+    "LABEL": "Radioer",
+    "LINE": "{name} ({type}): {soft}, {hard}",
+    "NONE": "Ingen Wi-Fi- eller Bluetooth-radioer fundet",
+    "WLAN": "Wi-Fi",
+    "BLUETOOTH": "Bluetooth"
+  },
+  "SOFT": {
+    "BLOCKED": "blokeret af software",
+    "UNBLOCKED": "ikke blokeret af software"
+  },
+  "HARD": {
+    "BLOCKED": "blokeret af hardware",
+    "UNBLOCKED": "ikke blokeret af hardware"
+  },
+  "RECOVERY": {
+    "LABEL": "Netværk",
+    "ETH": "Et kablet netværk er tilsluttet. Denne enhed kan stadig nås via kablet.",
+    "NO_ETH": "Intet kablet netværk. Hvis Wi-Fi eller flytilstand slås til, kan enheden kun nås fra denne skærm."
+  },
+  "HARDBLOCK": {
+    "NOTE": "En fysisk flyknap har slukket en radio. Det kan ikke ophæves i software."
+  },
+  "BUTTON": {
+    "ENABLE": "Slå flytilstand til",
+    "DISABLE": "Slå flytilstand fra",
+    "WIFI_DISABLE": "Slå Wi-Fi fra",
+    "WIFI_ENABLE": "Slå Wi-Fi til",
+    "BT_DISABLE": "Slå Bluetooth fra",
+    "BT_ENABLE": "Slå Bluetooth til"
+  },
+  "CONFIRM": {
+    "ENABLE_TITLE": "Slå flytilstand til?",
+    "ENABLE_ETH": "Wi-Fi og Bluetooth slukkes og forbliver slukket efter genstart. Denne enhed kan stadig nås via kablet.",
+    "ENABLE_NO_ETH": "Wi-Fi og Bluetooth slukkes og forbliver slukket efter genstart. Denne enhed kan derefter ikke nås via netværket. Du kan kun tænde radioerne igen fra denne skærm, eller ved at deaktivere pluginnet.",
+    "WIFI_TITLE": "Slå Wi-Fi fra?",
+    "WIFI_ETH": "Wi-Fi slukkes og forbliver slukket efter genstart. Denne enhed kan stadig nås via kablet.",
+    "WIFI_NO_ETH": "Wi-Fi slukkes og forbliver slukket efter genstart. Denne enhed kan derefter ikke nås via netværket. Du kan kun tænde Wi-Fi igen fra denne skærm, eller ved at deaktivere pluginnet."
+  },
+  "TOAST": {
+    "ENABLED": "Wi-Fi og Bluetooth er slukket",
+    "DISABLED": "Wi-Fi og Bluetooth er tændt",
+    "WIFI_OFF": "Wi-Fi er slukket",
+    "WIFI_ON": "Wi-Fi er tændt",
+    "BT_OFF": "Bluetooth er slukket",
+    "BT_ON": "Bluetooth er tændt",
+    "HARD_DENIED": "En hardwareknap blokerer en radio. Det kan ikke tilsidesættes.",
+    "FAILED": "Radiostatus kunne ikke anvendes"
+  }
+}

--- a/flightmode/i18n/strings_de.json
+++ b/flightmode/i18n/strings_de.json
@@ -1,0 +1,67 @@
+{
+  "PAGE": {
+    "LABEL": "Flugmodus"
+  },
+  "SECTION": {
+    "STATUS": "Status",
+    "RADIOS": "Funkmodule",
+    "CONTROL": "Flugmodus"
+  },
+  "STATUS": {
+    "LABEL": "Status",
+    "OFF": "Funk an",
+    "ON": "Flugmodus an",
+    "WIFI_OFF": "WLAN aus",
+    "BT_OFF": "Bluetooth aus",
+    "HARD": "Der Hardware-Flugzeugschalter ist an"
+  },
+  "RADIOS": {
+    "LABEL": "Funkmodule",
+    "LINE": "{name} ({type}): {soft}, {hard}",
+    "NONE": "Keine WLAN- oder Bluetooth-Funkmodule gefunden",
+    "WLAN": "WLAN",
+    "BLUETOOTH": "Bluetooth"
+  },
+  "SOFT": {
+    "BLOCKED": "softwareseitig gesperrt",
+    "UNBLOCKED": "softwareseitig nicht gesperrt"
+  },
+  "HARD": {
+    "BLOCKED": "hardwareseitig gesperrt",
+    "UNBLOCKED": "hardwareseitig nicht gesperrt"
+  },
+  "RECOVERY": {
+    "LABEL": "Netzwerk",
+    "ETH": "Ein Kabelnetzwerk ist verbunden. Dieses Gerät bleibt über das Kabel erreichbar.",
+    "NO_ETH": "Kein Kabelnetzwerk. Wenn WLAN oder der Flugmodus eingeschaltet wird, ist das Gerät nur noch über diesen Bildschirm erreichbar."
+  },
+  "HARDBLOCK": {
+    "NOTE": "Ein Hardware-Flugzeugschalter hat ein Funkmodul ausgeschaltet. Das lässt sich per Software nicht aufheben."
+  },
+  "BUTTON": {
+    "ENABLE": "Flugmodus einschalten",
+    "DISABLE": "Flugmodus ausschalten",
+    "WIFI_DISABLE": "WLAN ausschalten",
+    "WIFI_ENABLE": "WLAN einschalten",
+    "BT_DISABLE": "Bluetooth ausschalten",
+    "BT_ENABLE": "Bluetooth einschalten"
+  },
+  "CONFIRM": {
+    "ENABLE_TITLE": "Flugmodus einschalten?",
+    "ENABLE_ETH": "WLAN und Bluetooth werden ausgeschaltet und bleiben über einen Neustart hinweg aus. Dieses Gerät bleibt über das Kabel erreichbar.",
+    "ENABLE_NO_ETH": "WLAN und Bluetooth werden ausgeschaltet und bleiben über einen Neustart hinweg aus. Dieses Gerät ist dann über das Netzwerk nicht mehr erreichbar. Funkmodule können nur über diesen Bildschirm oder durch Deaktivieren des Plugins wieder eingeschaltet werden.",
+    "WIFI_TITLE": "WLAN ausschalten?",
+    "WIFI_ETH": "WLAN wird ausgeschaltet und bleibt über einen Neustart hinweg aus. Dieses Gerät bleibt über das Kabel erreichbar.",
+    "WIFI_NO_ETH": "WLAN wird ausgeschaltet und bleibt über einen Neustart hinweg aus. Dieses Gerät ist dann über das Netzwerk nicht mehr erreichbar. WLAN kann nur über diesen Bildschirm oder durch Deaktivieren des Plugins wieder eingeschaltet werden."
+  },
+  "TOAST": {
+    "ENABLED": "WLAN und Bluetooth sind aus",
+    "DISABLED": "WLAN und Bluetooth sind an",
+    "WIFI_OFF": "WLAN ist aus",
+    "WIFI_ON": "WLAN ist an",
+    "BT_OFF": "Bluetooth ist aus",
+    "BT_ON": "Bluetooth ist an",
+    "HARD_DENIED": "Ein Hardware-Schalter sperrt ein Funkmodul. Das lässt sich nicht übersteuern.",
+    "FAILED": "Funkzustand konnte nicht angewendet werden"
+  }
+}

--- a/flightmode/i18n/strings_en.json
+++ b/flightmode/i18n/strings_en.json
@@ -1,0 +1,67 @@
+{
+  "PAGE": {
+    "LABEL": "Flight Mode"
+  },
+  "SECTION": {
+    "STATUS": "Status",
+    "RADIOS": "Radios",
+    "CONTROL": "Flight mode"
+  },
+  "STATUS": {
+    "LABEL": "Status",
+    "OFF": "Radios on",
+    "ON": "Flight mode on",
+    "WIFI_OFF": "WiFi off",
+    "BT_OFF": "Bluetooth off",
+    "HARD": "Hardware airplane switch is on"
+  },
+  "RADIOS": {
+    "LABEL": "Radios",
+    "LINE": "{name} ({type}): {soft}, {hard}",
+    "NONE": "No WiFi or Bluetooth radios found",
+    "WLAN": "WiFi",
+    "BLUETOOTH": "Bluetooth"
+  },
+  "SOFT": {
+    "BLOCKED": "software blocked",
+    "UNBLOCKED": "not software blocked"
+  },
+  "HARD": {
+    "BLOCKED": "hardware blocked",
+    "UNBLOCKED": "not hardware blocked"
+  },
+  "RECOVERY": {
+    "LABEL": "Network",
+    "ETH": "A wired network is connected. You can still reach this device over the cable.",
+    "NO_ETH": "No wired network. Turning WiFi or flight mode on leaves the device reachable only from this screen."
+  },
+  "HARDBLOCK": {
+    "NOTE": "A hardware airplane switch has turned a radio off. That cannot be cleared in software."
+  },
+  "BUTTON": {
+    "ENABLE": "Enable flight mode",
+    "DISABLE": "Disable flight mode",
+    "WIFI_DISABLE": "Disable WiFi",
+    "WIFI_ENABLE": "Enable WiFi",
+    "BT_DISABLE": "Disable Bluetooth",
+    "BT_ENABLE": "Enable Bluetooth"
+  },
+  "CONFIRM": {
+    "ENABLE_TITLE": "Turn on flight mode?",
+    "ENABLE_ETH": "WiFi and Bluetooth will turn off and stay off across reboot. You can still reach this device over the cable.",
+    "ENABLE_NO_ETH": "WiFi and Bluetooth will turn off and stay off across reboot. This device will be unreachable over the network. You can turn radios back on only from this screen, or by disabling the plugin.",
+    "WIFI_TITLE": "Turn off WiFi?",
+    "WIFI_ETH": "WiFi will turn off and stay off across reboot. You can still reach this device over the cable.",
+    "WIFI_NO_ETH": "WiFi will turn off and stay off across reboot. This device will be unreachable over the network. You can turn WiFi back on only from this screen, or by disabling the plugin."
+  },
+  "TOAST": {
+    "ENABLED": "WiFi and Bluetooth are off",
+    "DISABLED": "WiFi and Bluetooth are on",
+    "WIFI_OFF": "WiFi is off",
+    "WIFI_ON": "WiFi is on",
+    "BT_OFF": "Bluetooth is off",
+    "BT_ON": "Bluetooth is on",
+    "HARD_DENIED": "A hardware switch is blocking a radio. This cannot override it.",
+    "FAILED": "Could not apply radio state"
+  }
+}

--- a/flightmode/i18n/strings_es.json
+++ b/flightmode/i18n/strings_es.json
@@ -1,0 +1,67 @@
+{
+  "PAGE": {
+    "LABEL": "Modo avión"
+  },
+  "SECTION": {
+    "STATUS": "Estado",
+    "RADIOS": "Radios",
+    "CONTROL": "Modo avión"
+  },
+  "STATUS": {
+    "LABEL": "Estado",
+    "OFF": "Radios encendidas",
+    "ON": "Modo avión activado",
+    "WIFI_OFF": "Wi-Fi apagado",
+    "BT_OFF": "Bluetooth apagado",
+    "HARD": "El interruptor de avión por hardware está activado"
+  },
+  "RADIOS": {
+    "LABEL": "Radios",
+    "LINE": "{name} ({type}): {soft}, {hard}",
+    "NONE": "No se han encontrado radios Wi-Fi o Bluetooth",
+    "WLAN": "Wi-Fi",
+    "BLUETOOTH": "Bluetooth"
+  },
+  "SOFT": {
+    "BLOCKED": "bloqueada por software",
+    "UNBLOCKED": "no bloqueada por software"
+  },
+  "HARD": {
+    "BLOCKED": "bloqueada por hardware",
+    "UNBLOCKED": "no bloqueada por hardware"
+  },
+  "RECOVERY": {
+    "LABEL": "Red",
+    "ETH": "Hay una red por cable conectada. Este dispositivo sigue siendo accesible por el cable.",
+    "NO_ETH": "No hay red por cable. Apagar el Wi-Fi o activar el modo avión deja el dispositivo accesible solo desde esta pantalla."
+  },
+  "HARDBLOCK": {
+    "NOTE": "Un interruptor de avión por hardware ha apagado una radio. No se puede desbloquear por software."
+  },
+  "BUTTON": {
+    "ENABLE": "Activar modo avión",
+    "DISABLE": "Desactivar modo avión",
+    "WIFI_DISABLE": "Desactivar Wi-Fi",
+    "WIFI_ENABLE": "Activar Wi-Fi",
+    "BT_DISABLE": "Desactivar Bluetooth",
+    "BT_ENABLE": "Activar Bluetooth"
+  },
+  "CONFIRM": {
+    "ENABLE_TITLE": "¿Activar el modo avión?",
+    "ENABLE_ETH": "Wi-Fi y Bluetooth se apagarán y seguirán apagados tras el reinicio. Este dispositivo seguirá siendo accesible por el cable.",
+    "ENABLE_NO_ETH": "Wi-Fi y Bluetooth se apagarán y seguirán apagados tras el reinicio. Este dispositivo dejará de ser accesible por la red. Solo podrá volver a encender las radios desde esta pantalla o desactivando el complemento.",
+    "WIFI_TITLE": "¿Apagar el Wi-Fi?",
+    "WIFI_ETH": "El Wi-Fi se apagará y seguirá apagado tras el reinicio. Este dispositivo seguirá siendo accesible por el cable.",
+    "WIFI_NO_ETH": "El Wi-Fi se apagará y seguirá apagado tras el reinicio. Este dispositivo dejará de ser accesible por la red. Solo podrá volver a encenderlo desde esta pantalla o desactivando el complemento."
+  },
+  "TOAST": {
+    "ENABLED": "Wi-Fi y Bluetooth están apagados",
+    "DISABLED": "Wi-Fi y Bluetooth están encendidos",
+    "WIFI_OFF": "El Wi-Fi está apagado",
+    "WIFI_ON": "El Wi-Fi está encendido",
+    "BT_OFF": "El Bluetooth está apagado",
+    "BT_ON": "El Bluetooth está encendido",
+    "HARD_DENIED": "Un interruptor de hardware está bloqueando una radio. No se puede anular.",
+    "FAILED": "No se pudo aplicar el estado de las radios"
+  }
+}

--- a/flightmode/i18n/strings_fi.json
+++ b/flightmode/i18n/strings_fi.json
@@ -1,0 +1,67 @@
+{
+  "PAGE": {
+    "LABEL": "Lentokonetila"
+  },
+  "SECTION": {
+    "STATUS": "Tila",
+    "RADIOS": "Radiot",
+    "CONTROL": "Lentokonetila"
+  },
+  "STATUS": {
+    "LABEL": "Tila",
+    "OFF": "Radiot päällä",
+    "ON": "Lentokonetila päällä",
+    "WIFI_OFF": "Wi-Fi pois päältä",
+    "BT_OFF": "Bluetooth pois päältä",
+    "HARD": "Laitteiston lentokonekytkin on päällä"
+  },
+  "RADIOS": {
+    "LABEL": "Radiot",
+    "LINE": "{name} ({type}): {soft}, {hard}",
+    "NONE": "Wi-Fi- tai Bluetooth-radioita ei löytynyt",
+    "WLAN": "Wi-Fi",
+    "BLUETOOTH": "Bluetooth"
+  },
+  "SOFT": {
+    "BLOCKED": "estetty ohjelmistolla",
+    "UNBLOCKED": "ei estetty ohjelmistolla"
+  },
+  "HARD": {
+    "BLOCKED": "estetty laitteistolla",
+    "UNBLOCKED": "ei estetty laitteistolla"
+  },
+  "RECOVERY": {
+    "LABEL": "Verkko",
+    "ETH": "Langallinen verkko on kytketty. Tämä laite on edelleen tavoitettavissa kaapelin kautta.",
+    "NO_ETH": "Ei langallista verkkoa. Jos Wi-Fi tai lentokonetila kytketään päälle, laite on tavoitettavissa vain tältä näytöltä."
+  },
+  "HARDBLOCK": {
+    "NOTE": "Laitteiston lentokonekytkin on sammuttanut radion. Sitä ei voi poistaa ohjelmistolla."
+  },
+  "BUTTON": {
+    "ENABLE": "Ota lentokonetila käyttöön",
+    "DISABLE": "Poista lentokonetila käytöstä",
+    "WIFI_DISABLE": "Poista Wi-Fi käytöstä",
+    "WIFI_ENABLE": "Ota Wi-Fi käyttöön",
+    "BT_DISABLE": "Poista Bluetooth käytöstä",
+    "BT_ENABLE": "Ota Bluetooth käyttöön"
+  },
+  "CONFIRM": {
+    "ENABLE_TITLE": "Otetaanko lentokonetila käyttöön?",
+    "ENABLE_ETH": "Wi-Fi ja Bluetooth sammutetaan, ja ne pysyvät pois päältä uudelleenkäynnistyksen jälkeen. Tämä laite on edelleen tavoitettavissa kaapelin kautta.",
+    "ENABLE_NO_ETH": "Wi-Fi ja Bluetooth sammutetaan, ja ne pysyvät pois päältä uudelleenkäynnistyksen jälkeen. Tätä laitetta ei sen jälkeen tavoita verkosta. Radiot voi kytkeä takaisin päälle vain tältä näytöltä tai poistamalla laajennuksen käytöstä.",
+    "WIFI_TITLE": "Sammutetaanko Wi-Fi?",
+    "WIFI_ETH": "Wi-Fi sammutetaan, ja se pysyy pois päältä uudelleenkäynnistyksen jälkeen. Tämä laite on edelleen tavoitettavissa kaapelin kautta.",
+    "WIFI_NO_ETH": "Wi-Fi sammutetaan, ja se pysyy pois päältä uudelleenkäynnistyksen jälkeen. Tätä laitetta ei sen jälkeen tavoita verkosta. Wi-Fin voi kytkeä takaisin päälle vain tältä näytöltä tai poistamalla laajennuksen käytöstä."
+  },
+  "TOAST": {
+    "ENABLED": "Wi-Fi ja Bluetooth ovat pois päältä",
+    "DISABLED": "Wi-Fi ja Bluetooth ovat päällä",
+    "WIFI_OFF": "Wi-Fi on pois päältä",
+    "WIFI_ON": "Wi-Fi on päällä",
+    "BT_OFF": "Bluetooth on pois päältä",
+    "BT_ON": "Bluetooth on päällä",
+    "HARD_DENIED": "Laitteistokytkin estää radion. Sitä ei voi ohittaa.",
+    "FAILED": "Radiotilaa ei voitu ottaa käyttöön"
+  }
+}

--- a/flightmode/i18n/strings_fr.json
+++ b/flightmode/i18n/strings_fr.json
@@ -1,0 +1,67 @@
+{
+  "PAGE": {
+    "LABEL": "Mode avion"
+  },
+  "SECTION": {
+    "STATUS": "État",
+    "RADIOS": "Radios",
+    "CONTROL": "Mode avion"
+  },
+  "STATUS": {
+    "LABEL": "État",
+    "OFF": "Radios allumées",
+    "ON": "Mode avion activé",
+    "WIFI_OFF": "Wi-Fi éteint",
+    "BT_OFF": "Bluetooth éteint",
+    "HARD": "L’interrupteur avion matériel est activé"
+  },
+  "RADIOS": {
+    "LABEL": "Radios",
+    "LINE": "{name} ({type}) : {soft}, {hard}",
+    "NONE": "Aucune radio Wi-Fi ou Bluetooth trouvée",
+    "WLAN": "Wi-Fi",
+    "BLUETOOTH": "Bluetooth"
+  },
+  "SOFT": {
+    "BLOCKED": "bloquée par logiciel",
+    "UNBLOCKED": "non bloquée par logiciel"
+  },
+  "HARD": {
+    "BLOCKED": "bloquée matériellement",
+    "UNBLOCKED": "non bloquée matériellement"
+  },
+  "RECOVERY": {
+    "LABEL": "Réseau",
+    "ETH": "Un réseau filaire est connecté. Cet appareil reste joignable par le câble.",
+    "NO_ETH": "Aucun réseau filaire. Couper le Wi-Fi ou activer le mode avion ne laisse l’appareil joignable que depuis cet écran."
+  },
+  "HARDBLOCK": {
+    "NOTE": "Un interrupteur avion matériel a éteint une radio. Cela ne peut pas être annulé par logiciel."
+  },
+  "BUTTON": {
+    "ENABLE": "Activer le mode avion",
+    "DISABLE": "Désactiver le mode avion",
+    "WIFI_DISABLE": "Désactiver le Wi-Fi",
+    "WIFI_ENABLE": "Activer le Wi-Fi",
+    "BT_DISABLE": "Désactiver le Bluetooth",
+    "BT_ENABLE": "Activer le Bluetooth"
+  },
+  "CONFIRM": {
+    "ENABLE_TITLE": "Activer le mode avion ?",
+    "ENABLE_ETH": "Le Wi-Fi et le Bluetooth seront éteints et le resteront après un redémarrage. Cet appareil reste joignable par le câble.",
+    "ENABLE_NO_ETH": "Le Wi-Fi et le Bluetooth seront éteints et le resteront après un redémarrage. Cet appareil ne sera plus joignable sur le réseau. Vous ne pourrez rallumer les radios que depuis cet écran, ou en désactivant le greffon.",
+    "WIFI_TITLE": "Éteindre le Wi-Fi ?",
+    "WIFI_ETH": "Le Wi-Fi sera éteint et le restera après un redémarrage. Cet appareil reste joignable par le câble.",
+    "WIFI_NO_ETH": "Le Wi-Fi sera éteint et le restera après un redémarrage. Cet appareil ne sera plus joignable sur le réseau. Vous ne pourrez le rallumer que depuis cet écran, ou en désactivant le greffon."
+  },
+  "TOAST": {
+    "ENABLED": "Wi-Fi et Bluetooth sont éteints",
+    "DISABLED": "Wi-Fi et Bluetooth sont allumés",
+    "WIFI_OFF": "Le Wi-Fi est éteint",
+    "WIFI_ON": "Le Wi-Fi est allumé",
+    "BT_OFF": "Le Bluetooth est éteint",
+    "BT_ON": "Le Bluetooth est allumé",
+    "HARD_DENIED": "Un interrupteur matériel bloque une radio. Impossible de le contourner.",
+    "FAILED": "Impossible d’appliquer l’état des radios"
+  }
+}

--- a/flightmode/i18n/strings_it.json
+++ b/flightmode/i18n/strings_it.json
@@ -1,0 +1,67 @@
+{
+  "PAGE": {
+    "LABEL": "Modalità aereo"
+  },
+  "SECTION": {
+    "STATUS": "Stato",
+    "RADIOS": "Radio",
+    "CONTROL": "Modalità aereo"
+  },
+  "STATUS": {
+    "LABEL": "Stato",
+    "OFF": "Radio accese",
+    "ON": "Modalità aereo attiva",
+    "WIFI_OFF": "Wi-Fi spento",
+    "BT_OFF": "Bluetooth spento",
+    "HARD": "L’interruttore aereo hardware è attivo"
+  },
+  "RADIOS": {
+    "LABEL": "Radio",
+    "LINE": "{name} ({type}): {soft}, {hard}",
+    "NONE": "Nessuna radio Wi-Fi o Bluetooth trovata",
+    "WLAN": "Wi-Fi",
+    "BLUETOOTH": "Bluetooth"
+  },
+  "SOFT": {
+    "BLOCKED": "bloccata via software",
+    "UNBLOCKED": "non bloccata via software"
+  },
+  "HARD": {
+    "BLOCKED": "bloccata via hardware",
+    "UNBLOCKED": "non bloccata via hardware"
+  },
+  "RECOVERY": {
+    "LABEL": "Rete",
+    "ETH": "È collegata una rete cablata. Questo dispositivo resta raggiungibile via cavo.",
+    "NO_ETH": "Nessuna rete cablata. Spegnendo il Wi-Fi o attivando la modalità aereo, il dispositivo è raggiungibile solo da questa schermata."
+  },
+  "HARDBLOCK": {
+    "NOTE": "Un interruttore aereo hardware ha spento una radio. Non è possibile sbloccarla via software."
+  },
+  "BUTTON": {
+    "ENABLE": "Attiva modalità aereo",
+    "DISABLE": "Disattiva modalità aereo",
+    "WIFI_DISABLE": "Disattiva Wi-Fi",
+    "WIFI_ENABLE": "Attiva Wi-Fi",
+    "BT_DISABLE": "Disattiva Bluetooth",
+    "BT_ENABLE": "Attiva Bluetooth"
+  },
+  "CONFIRM": {
+    "ENABLE_TITLE": "Attivare la modalità aereo?",
+    "ENABLE_ETH": "Wi-Fi e Bluetooth verranno spenti e resteranno spenti dopo il riavvio. Questo dispositivo resta raggiungibile via cavo.",
+    "ENABLE_NO_ETH": "Wi-Fi e Bluetooth verranno spenti e resteranno spenti dopo il riavvio. Questo dispositivo non sarà più raggiungibile in rete. Potrai riaccendere le radio solo da questa schermata, o disattivando il plugin.",
+    "WIFI_TITLE": "Spegnere il Wi-Fi?",
+    "WIFI_ETH": "Il Wi-Fi verrà spento e resterà spento dopo il riavvio. Questo dispositivo resta raggiungibile via cavo.",
+    "WIFI_NO_ETH": "Il Wi-Fi verrà spento e resterà spento dopo il riavvio. Questo dispositivo non sarà più raggiungibile in rete. Potrai riaccendere il Wi-Fi solo da questa schermata, o disattivando il plugin."
+  },
+  "TOAST": {
+    "ENABLED": "Wi-Fi e Bluetooth sono spenti",
+    "DISABLED": "Wi-Fi e Bluetooth sono accesi",
+    "WIFI_OFF": "Il Wi-Fi è spento",
+    "WIFI_ON": "Il Wi-Fi è acceso",
+    "BT_OFF": "Il Bluetooth è spento",
+    "BT_ON": "Il Bluetooth è acceso",
+    "HARD_DENIED": "Un interruttore hardware sta bloccando una radio. Non è possibile ignorarlo.",
+    "FAILED": "Impossibile applicare lo stato delle radio"
+  }
+}

--- a/flightmode/i18n/strings_nl.json
+++ b/flightmode/i18n/strings_nl.json
@@ -1,0 +1,67 @@
+{
+  "PAGE": {
+    "LABEL": "Vliegtuigmodus"
+  },
+  "SECTION": {
+    "STATUS": "Status",
+    "RADIOS": "Radio’s",
+    "CONTROL": "Vliegtuigmodus"
+  },
+  "STATUS": {
+    "LABEL": "Status",
+    "OFF": "Radio’s aan",
+    "ON": "Vliegtuigmodus aan",
+    "WIFI_OFF": "Wifi uit",
+    "BT_OFF": "Bluetooth uit",
+    "HARD": "De hardware-vliegtuigschakelaar staat aan"
+  },
+  "RADIOS": {
+    "LABEL": "Radio’s",
+    "LINE": "{name} ({type}): {soft}, {hard}",
+    "NONE": "Geen wifi- of bluetoothradio’s gevonden",
+    "WLAN": "Wifi",
+    "BLUETOOTH": "Bluetooth"
+  },
+  "SOFT": {
+    "BLOCKED": "softwarematig geblokkeerd",
+    "UNBLOCKED": "niet softwarematig geblokkeerd"
+  },
+  "HARD": {
+    "BLOCKED": "hardwarematig geblokkeerd",
+    "UNBLOCKED": "niet hardwarematig geblokkeerd"
+  },
+  "RECOVERY": {
+    "LABEL": "Netwerk",
+    "ETH": "Er is een bekabeld netwerk verbonden. Dit apparaat blijft via de kabel bereikbaar.",
+    "NO_ETH": "Geen bekabeld netwerk. Wifi of vliegtuigmodus inschakelen maakt het apparaat alleen via dit scherm bereikbaar."
+  },
+  "HARDBLOCK": {
+    "NOTE": "Een hardware-vliegtuigschakelaar heeft een radio uitgeschakeld. Dat kan niet via software ongedaan worden gemaakt."
+  },
+  "BUTTON": {
+    "ENABLE": "Vliegtuigmodus inschakelen",
+    "DISABLE": "Vliegtuigmodus uitschakelen",
+    "WIFI_DISABLE": "Wifi uitschakelen",
+    "WIFI_ENABLE": "Wifi inschakelen",
+    "BT_DISABLE": "Bluetooth uitschakelen",
+    "BT_ENABLE": "Bluetooth inschakelen"
+  },
+  "CONFIRM": {
+    "ENABLE_TITLE": "Vliegtuigmodus inschakelen?",
+    "ENABLE_ETH": "Wifi en bluetooth gaan uit en blijven uit na een herstart. Dit apparaat blijft via de kabel bereikbaar.",
+    "ENABLE_NO_ETH": "Wifi en bluetooth gaan uit en blijven uit na een herstart. Dit apparaat is dan niet meer via het netwerk bereikbaar. Je kunt de radio’s alleen weer inschakelen via dit scherm, of door de plugin uit te schakelen.",
+    "WIFI_TITLE": "Wifi uitschakelen?",
+    "WIFI_ETH": "Wifi gaat uit en blijft uit na een herstart. Dit apparaat blijft via de kabel bereikbaar.",
+    "WIFI_NO_ETH": "Wifi gaat uit en blijft uit na een herstart. Dit apparaat is dan niet meer via het netwerk bereikbaar. Je kunt wifi alleen weer inschakelen via dit scherm, of door de plugin uit te schakelen."
+  },
+  "TOAST": {
+    "ENABLED": "Wifi en bluetooth zijn uit",
+    "DISABLED": "Wifi en bluetooth zijn aan",
+    "WIFI_OFF": "Wifi is uit",
+    "WIFI_ON": "Wifi is aan",
+    "BT_OFF": "Bluetooth is uit",
+    "BT_ON": "Bluetooth is aan",
+    "HARD_DENIED": "Een hardwareschakelaar blokkeert een radio. Dat kan niet worden overschreven.",
+    "FAILED": "Radiostatus kon niet worden toegepast"
+  }
+}

--- a/flightmode/i18n/strings_no.json
+++ b/flightmode/i18n/strings_no.json
@@ -1,0 +1,67 @@
+{
+  "PAGE": {
+    "LABEL": "Flymodus"
+  },
+  "SECTION": {
+    "STATUS": "Status",
+    "RADIOS": "Radioer",
+    "CONTROL": "Flymodus"
+  },
+  "STATUS": {
+    "LABEL": "Status",
+    "OFF": "Radioer på",
+    "ON": "Flymodus på",
+    "WIFI_OFF": "Wi-Fi av",
+    "BT_OFF": "Bluetooth av",
+    "HARD": "Den fysiske flyknappen er på"
+  },
+  "RADIOS": {
+    "LABEL": "Radioer",
+    "LINE": "{name} ({type}): {soft}, {hard}",
+    "NONE": "Ingen Wi-Fi- eller Bluetooth-radioer funnet",
+    "WLAN": "Wi-Fi",
+    "BLUETOOTH": "Bluetooth"
+  },
+  "SOFT": {
+    "BLOCKED": "programvareblokkert",
+    "UNBLOCKED": "ikke programvareblokkert"
+  },
+  "HARD": {
+    "BLOCKED": "maskinvareblokkert",
+    "UNBLOCKED": "ikke maskinvareblokkert"
+  },
+  "RECOVERY": {
+    "LABEL": "Nettverk",
+    "ETH": "Et kablet nettverk er tilkoblet. Denne enheten kan fortsatt nås via kabelen.",
+    "NO_ETH": "Ingen kablet nettverk. Hvis Wi-Fi eller flymodus slås på, kan enheten bare nås fra denne skjermen."
+  },
+  "HARDBLOCK": {
+    "NOTE": "En fysisk flyknapp har slått av en radio. Det kan ikke oppheves i programvare."
+  },
+  "BUTTON": {
+    "ENABLE": "Slå på flymodus",
+    "DISABLE": "Slå av flymodus",
+    "WIFI_DISABLE": "Slå av Wi-Fi",
+    "WIFI_ENABLE": "Slå på Wi-Fi",
+    "BT_DISABLE": "Slå av Bluetooth",
+    "BT_ENABLE": "Slå på Bluetooth"
+  },
+  "CONFIRM": {
+    "ENABLE_TITLE": "Slå på flymodus?",
+    "ENABLE_ETH": "Wi-Fi og Bluetooth slås av og forblir av etter omstart. Denne enheten kan fortsatt nås via kabelen.",
+    "ENABLE_NO_ETH": "Wi-Fi og Bluetooth slås av og forblir av etter omstart. Denne enheten kan da ikke nås over nettverket. Du kan bare slå radioene på igjen fra denne skjermen, eller ved å deaktivere programtillegget.",
+    "WIFI_TITLE": "Slå av Wi-Fi?",
+    "WIFI_ETH": "Wi-Fi slås av og forblir av etter omstart. Denne enheten kan fortsatt nås via kabelen.",
+    "WIFI_NO_ETH": "Wi-Fi slås av og forblir av etter omstart. Denne enheten kan da ikke nås over nettverket. Du kan bare slå Wi-Fi på igjen fra denne skjermen, eller ved å deaktivere programtillegget."
+  },
+  "TOAST": {
+    "ENABLED": "Wi-Fi og Bluetooth er av",
+    "DISABLED": "Wi-Fi og Bluetooth er på",
+    "WIFI_OFF": "Wi-Fi er av",
+    "WIFI_ON": "Wi-Fi er på",
+    "BT_OFF": "Bluetooth er av",
+    "BT_ON": "Bluetooth er på",
+    "HARD_DENIED": "En maskinvareknapp blokkerer en radio. Det kan ikke overstyres.",
+    "FAILED": "Kunne ikke ta i bruk radiostatus"
+  }
+}

--- a/flightmode/i18n/strings_pl.json
+++ b/flightmode/i18n/strings_pl.json
@@ -1,0 +1,67 @@
+{
+  "PAGE": {
+    "LABEL": "Tryb samolotowy"
+  },
+  "SECTION": {
+    "STATUS": "Stan",
+    "RADIOS": "Radia",
+    "CONTROL": "Tryb samolotowy"
+  },
+  "STATUS": {
+    "LABEL": "Stan",
+    "OFF": "Radia włączone",
+    "ON": "Tryb samolotowy włączony",
+    "WIFI_OFF": "Wi-Fi wyłączone",
+    "BT_OFF": "Bluetooth wyłączony",
+    "HARD": "Sprzętowy przełącznik trybu samolotowego jest włączony"
+  },
+  "RADIOS": {
+    "LABEL": "Radia",
+    "LINE": "{name} ({type}): {soft}, {hard}",
+    "NONE": "Nie znaleziono radia Wi-Fi ani Bluetooth",
+    "WLAN": "Wi-Fi",
+    "BLUETOOTH": "Bluetooth"
+  },
+  "SOFT": {
+    "BLOCKED": "zablokowane programowo",
+    "UNBLOCKED": "niezablokowane programowo"
+  },
+  "HARD": {
+    "BLOCKED": "zablokowane sprzętowo",
+    "UNBLOCKED": "niezablokowane sprzętowo"
+  },
+  "RECOVERY": {
+    "LABEL": "Sieć",
+    "ETH": "Podłączona jest sieć przewodowa. To urządzenie pozostaje dostępne przez kabel.",
+    "NO_ETH": "Brak sieci przewodowej. Wyłączenie Wi-Fi lub włączenie trybu samolotowego pozostawia urządzenie dostępne tylko z tego ekranu."
+  },
+  "HARDBLOCK": {
+    "NOTE": "Sprzętowy przełącznik trybu samolotowego wyłączył radio. Tego nie da się odblokować programowo."
+  },
+  "BUTTON": {
+    "ENABLE": "Włącz tryb samolotowy",
+    "DISABLE": "Wyłącz tryb samolotowy",
+    "WIFI_DISABLE": "Wyłącz Wi-Fi",
+    "WIFI_ENABLE": "Włącz Wi-Fi",
+    "BT_DISABLE": "Wyłącz Bluetooth",
+    "BT_ENABLE": "Włącz Bluetooth"
+  },
+  "CONFIRM": {
+    "ENABLE_TITLE": "Włączyć tryb samolotowy?",
+    "ENABLE_ETH": "Wi-Fi i Bluetooth zostaną wyłączone i pozostaną wyłączone po restarcie. To urządzenie pozostanie dostępne przez kabel.",
+    "ENABLE_NO_ETH": "Wi-Fi i Bluetooth zostaną wyłączone i pozostaną wyłączone po restarcie. To urządzenie nie będzie dostępne w sieci. Radia można włączyć ponownie tylko z tego ekranu albo wyłączając wtyczkę.",
+    "WIFI_TITLE": "Wyłączyć Wi-Fi?",
+    "WIFI_ETH": "Wi-Fi zostanie wyłączone i pozostanie wyłączone po restarcie. To urządzenie pozostanie dostępne przez kabel.",
+    "WIFI_NO_ETH": "Wi-Fi zostanie wyłączone i pozostanie wyłączone po restarcie. To urządzenie nie będzie dostępne w sieci. Wi-Fi można włączyć ponownie tylko z tego ekranu albo wyłączając wtyczkę."
+  },
+  "TOAST": {
+    "ENABLED": "Wi-Fi i Bluetooth są wyłączone",
+    "DISABLED": "Wi-Fi i Bluetooth są włączone",
+    "WIFI_OFF": "Wi-Fi jest wyłączone",
+    "WIFI_ON": "Wi-Fi jest włączone",
+    "BT_OFF": "Bluetooth jest wyłączony",
+    "BT_ON": "Bluetooth jest włączony",
+    "HARD_DENIED": "Przełącznik sprzętowy blokuje radio. Nie można tego nadpisać.",
+    "FAILED": "Nie udało się zastosować stanu radiów"
+  }
+}

--- a/flightmode/i18n/strings_pt.json
+++ b/flightmode/i18n/strings_pt.json
@@ -1,0 +1,67 @@
+{
+  "PAGE": {
+    "LABEL": "Modo de voo"
+  },
+  "SECTION": {
+    "STATUS": "Estado",
+    "RADIOS": "Rádios",
+    "CONTROL": "Modo de voo"
+  },
+  "STATUS": {
+    "LABEL": "Estado",
+    "OFF": "Rádios ligados",
+    "ON": "Modo de voo ligado",
+    "WIFI_OFF": "Wi-Fi desligado",
+    "BT_OFF": "Bluetooth desligado",
+    "HARD": "O interruptor de avião por hardware está ligado"
+  },
+  "RADIOS": {
+    "LABEL": "Rádios",
+    "LINE": "{name} ({type}): {soft}, {hard}",
+    "NONE": "Não foram encontrados rádios Wi-Fi ou Bluetooth",
+    "WLAN": "Wi-Fi",
+    "BLUETOOTH": "Bluetooth"
+  },
+  "SOFT": {
+    "BLOCKED": "bloqueado por software",
+    "UNBLOCKED": "não bloqueado por software"
+  },
+  "HARD": {
+    "BLOCKED": "bloqueado por hardware",
+    "UNBLOCKED": "não bloqueado por hardware"
+  },
+  "RECOVERY": {
+    "LABEL": "Rede",
+    "ETH": "Há uma rede com fios ligada. Este dispositivo continua acessível pelo cabo.",
+    "NO_ETH": "Não há rede com fios. Desligar o Wi-Fi ou ativar o modo de voo deixa o dispositivo acessível apenas neste ecrã."
+  },
+  "HARDBLOCK": {
+    "NOTE": "Um interruptor de avião por hardware desligou um rádio. Isso não pode ser anulado por software."
+  },
+  "BUTTON": {
+    "ENABLE": "Ativar modo de voo",
+    "DISABLE": "Desativar modo de voo",
+    "WIFI_DISABLE": "Desativar Wi-Fi",
+    "WIFI_ENABLE": "Ativar Wi-Fi",
+    "BT_DISABLE": "Desativar Bluetooth",
+    "BT_ENABLE": "Ativar Bluetooth"
+  },
+  "CONFIRM": {
+    "ENABLE_TITLE": "Ativar o modo de voo?",
+    "ENABLE_ETH": "O Wi-Fi e o Bluetooth serão desligados e permanecerão desligados após o reinício. Este dispositivo continua acessível pelo cabo.",
+    "ENABLE_NO_ETH": "O Wi-Fi e o Bluetooth serão desligados e permanecerão desligados após o reinício. Este dispositivo deixará de ser acessível na rede. Só poderá voltar a ligar os rádios neste ecrã, ou desativando o plugin.",
+    "WIFI_TITLE": "Desligar o Wi-Fi?",
+    "WIFI_ETH": "O Wi-Fi será desligado e permanecerá desligado após o reinício. Este dispositivo continua acessível pelo cabo.",
+    "WIFI_NO_ETH": "O Wi-Fi será desligado e permanecerá desligado após o reinício. Este dispositivo deixará de ser acessível na rede. Só poderá voltar a ligá-lo neste ecrã, ou desativando o plugin."
+  },
+  "TOAST": {
+    "ENABLED": "Wi-Fi e Bluetooth estão desligados",
+    "DISABLED": "Wi-Fi e Bluetooth estão ligados",
+    "WIFI_OFF": "O Wi-Fi está desligado",
+    "WIFI_ON": "O Wi-Fi está ligado",
+    "BT_OFF": "O Bluetooth está desligado",
+    "BT_ON": "O Bluetooth está ligado",
+    "HARD_DENIED": "Um interruptor de hardware está a bloquear um rádio. Não é possível anulá-lo.",
+    "FAILED": "Não foi possível aplicar o estado dos rádios"
+  }
+}

--- a/flightmode/i18n/strings_sv.json
+++ b/flightmode/i18n/strings_sv.json
@@ -1,0 +1,67 @@
+{
+  "PAGE": {
+    "LABEL": "Flygplansläge"
+  },
+  "SECTION": {
+    "STATUS": "Status",
+    "RADIOS": "Radio",
+    "CONTROL": "Flygplansläge"
+  },
+  "STATUS": {
+    "LABEL": "Status",
+    "OFF": "Radio på",
+    "ON": "Flygplansläge på",
+    "WIFI_OFF": "Wi-Fi av",
+    "BT_OFF": "Bluetooth av",
+    "HARD": "Den fysiska flygplansknappen är på"
+  },
+  "RADIOS": {
+    "LABEL": "Radio",
+    "LINE": "{name} ({type}): {soft}, {hard}",
+    "NONE": "Inga Wi-Fi- eller Bluetooth-radioenheter hittades",
+    "WLAN": "Wi-Fi",
+    "BLUETOOTH": "Bluetooth"
+  },
+  "SOFT": {
+    "BLOCKED": "programvaruspärrad",
+    "UNBLOCKED": "inte programvaruspärrad"
+  },
+  "HARD": {
+    "BLOCKED": "hårdvaruspärrad",
+    "UNBLOCKED": "inte hårdvaruspärrad"
+  },
+  "RECOVERY": {
+    "LABEL": "Nätverk",
+    "ETH": "Ett trådbundet nätverk är anslutet. Den här enheten går fortfarande att nå via kabeln.",
+    "NO_ETH": "Inget trådbundet nätverk. Om Wi-Fi eller flygplansläge slås på går enheten bara att nå från den här skärmen."
+  },
+  "HARDBLOCK": {
+    "NOTE": "En fysisk flygplansknapp har stängt av en radio. Det kan inte hävas i programvara."
+  },
+  "BUTTON": {
+    "ENABLE": "Aktivera flygplansläge",
+    "DISABLE": "Inaktivera flygplansläge",
+    "WIFI_DISABLE": "Inaktivera Wi-Fi",
+    "WIFI_ENABLE": "Aktivera Wi-Fi",
+    "BT_DISABLE": "Inaktivera Bluetooth",
+    "BT_ENABLE": "Aktivera Bluetooth"
+  },
+  "CONFIRM": {
+    "ENABLE_TITLE": "Aktivera flygplansläge?",
+    "ENABLE_ETH": "Wi-Fi och Bluetooth stängs av och förblir avstängda efter omstart. Den här enheten går fortfarande att nå via kabeln.",
+    "ENABLE_NO_ETH": "Wi-Fi och Bluetooth stängs av och förblir avstängda efter omstart. Den här enheten går då inte att nå via nätverket. Du kan bara slå på radion igen från den här skärmen, eller genom att inaktivera insticksprogrammet.",
+    "WIFI_TITLE": "Stänga av Wi-Fi?",
+    "WIFI_ETH": "Wi-Fi stängs av och förblir avstängt efter omstart. Den här enheten går fortfarande att nå via kabeln.",
+    "WIFI_NO_ETH": "Wi-Fi stängs av och förblir avstängt efter omstart. Den här enheten går då inte att nå via nätverket. Du kan bara slå på Wi-Fi igen från den här skärmen, eller genom att inaktivera insticksprogrammet."
+  },
+  "TOAST": {
+    "ENABLED": "Wi-Fi och Bluetooth är av",
+    "DISABLED": "Wi-Fi och Bluetooth är på",
+    "WIFI_OFF": "Wi-Fi är av",
+    "WIFI_ON": "Wi-Fi är på",
+    "BT_OFF": "Bluetooth är av",
+    "BT_ON": "Bluetooth är på",
+    "HARD_DENIED": "En hårdvaruknapp blockerar en radio. Det kan inte åsidosättas.",
+    "FAILED": "Kunde inte tillämpa radiostatus"
+  }
+}

--- a/flightmode/index.js
+++ b/flightmode/index.js
@@ -1,0 +1,563 @@
+'use strict';
+
+var libQ = require('kew');
+var fs = require('fs-extra');
+var path = require('path');
+var exec = require('child_process').exec;
+
+var LOG_PREFIX = '[FlightMode] ';
+var UNIT_SERVICE = 'volumio-flightmode.service';
+var UNIT_PATH = 'volumio-flightmode.path';
+var SYSTEMD_DIR = '/etc/systemd/system';
+var RFKILL_CLASS = '/sys/class/rfkill';
+var NET_CLASS = '/sys/class/net';
+
+module.exports = ControllerFlightMode;
+
+function ControllerFlightMode(context) {
+  this.context = context;
+  this.commandRouter = this.context.coreCommand;
+  this.logger = this.context.logger;
+  this.configManager = this.context.configManager;
+  this._strings = null;
+}
+
+ControllerFlightMode.prototype.onVolumioStart = function () {
+  var configFile = this.commandRouter.pluginManager.getConfigurationFile(this.context, 'config.json');
+  this.config = new (require('v-conf'))();
+  this.config.loadFile(configFile);
+  this._loadStrings();
+  return libQ.resolve();
+};
+
+ControllerFlightMode.prototype.getConfigurationFiles = function () {
+  return ['config.json'];
+};
+
+ControllerFlightMode.prototype.onStart = function () {
+  var self = this;
+  self._loadStrings();
+  self._ensureStateFiles();
+
+  return self._writeServiceUnit()
+    .then(function () {
+      return self._generatePathUnit();
+    })
+    .then(function () {
+      return self._linkUnits();
+    })
+    .then(function () {
+      return self._sudo('/bin/systemctl daemon-reload');
+    })
+    .then(function () {
+      return self._sudo('/bin/systemctl enable --now ' + UNIT_SERVICE + ' ' + UNIT_PATH);
+    })
+    .fail(function (err) {
+      self.logger.error(LOG_PREFIX + 'onStart failed: ' + err);
+      return libQ.reject(err);
+    });
+};
+
+ControllerFlightMode.prototype.onStop = function () {
+  var self = this;
+
+  return self._writeRadioState(true, true)
+    .then(function () {
+      return self._writeMode('release');
+    })
+    .then(function () {
+      return self._sudo('/bin/systemctl start ' + UNIT_SERVICE);
+    })
+    .fail(function (err) {
+      self.logger.error(LOG_PREFIX + 'onStop release failed: ' + err);
+      return libQ.resolve();
+    })
+    .then(function () {
+      return self._sudo('/bin/systemctl disable --now ' + UNIT_PATH + ' ' + UNIT_SERVICE);
+    })
+    .fail(function (err) {
+      self.logger.error(LOG_PREFIX + 'onStop disable failed: ' + err);
+      return libQ.resolve();
+    })
+    .then(function () {
+      return self._sudo('/bin/rm -f ' + path.join(SYSTEMD_DIR, UNIT_PATH) + ' ' + path.join(SYSTEMD_DIR, UNIT_SERVICE));
+    })
+    .then(function () {
+      return self._sudo('/bin/systemctl daemon-reload');
+    })
+    .fail(function (err) {
+      self.logger.error(LOG_PREFIX + 'onStop cleanup failed: ' + err);
+      return libQ.resolve();
+    });
+};
+
+ControllerFlightMode.prototype.onRestart = function () {
+};
+
+// UI ---------------------------------------------------------------------------
+// sections[0] = section_status    status_text, radios_text, recovery_text
+// sections[1] = section_radios    disable_wifi, enable_wifi, disable_bluetooth, enable_bluetooth
+// sections[2] = section_control   enable_flightmode, disable_flightmode, hardblock_note
+
+ControllerFlightMode.prototype.getUIConfig = function () {
+  var defer = libQ.defer();
+  var self = this;
+  var langCode = this.commandRouter.sharedVars.get('language_code');
+
+  self._loadStrings();
+
+  self.commandRouter.i18nJson(
+    self._i18nPath(langCode),
+    path.join(__dirname, 'i18n', 'strings_en.json'),
+    path.join(__dirname, 'UIConfig.json')
+  ).then(function (uiconf) {
+    var wifiOn = self._isRadioOn('wifi');
+    var btOn = self._isRadioOn('bluetooth');
+    var flightOn = !wifiOn && !btOn;
+    var hasEth = self._hasWiredCarrier();
+    var radios = self._readRadios();
+    var wifiHard = radios.some(function (r) { return r.type === 'wlan' && r.hard; });
+    var btHard = radios.some(function (r) { return r.type === 'bluetooth' && r.hard; });
+    var anyHard = wifiHard || btHard;
+
+    var statusSection = self._sectionById(uiconf, 'section_status');
+    var radiosSection = self._sectionById(uiconf, 'section_radios');
+    var controlSection = self._sectionById(uiconf, 'section_control');
+
+    var statusItem = self._contentById(statusSection, 'status_text');
+    var radiosItem = self._contentById(statusSection, 'radios_text');
+    var recoveryItem = self._contentById(statusSection, 'recovery_text');
+    var disableWifi = self._contentById(radiosSection, 'disable_wifi');
+    var enableWifi = self._contentById(radiosSection, 'enable_wifi');
+    var disableBt = self._contentById(radiosSection, 'disable_bluetooth');
+    var enableBt = self._contentById(radiosSection, 'enable_bluetooth');
+    var enableFlight = self._contentById(controlSection, 'enable_flightmode');
+    var disableFlight = self._contentById(controlSection, 'disable_flightmode');
+    var hardNote = self._contentById(controlSection, 'hardblock_note');
+
+    if (statusItem) {
+      if (anyHard) {
+        statusItem.value = self._t('STATUS.HARD');
+      } else if (flightOn) {
+        statusItem.value = self._t('STATUS.ON');
+      } else if (!wifiOn) {
+        statusItem.value = self._t('STATUS.WIFI_OFF');
+      } else if (!btOn) {
+        statusItem.value = self._t('STATUS.BT_OFF');
+      } else {
+        statusItem.value = self._t('STATUS.OFF');
+      }
+    }
+
+    if (radiosItem) {
+      radiosItem.value = self._formatRadios(radios);
+    }
+
+    if (recoveryItem) {
+      recoveryItem.value = hasEth ? self._t('RECOVERY.ETH') : self._t('RECOVERY.NO_ETH');
+    }
+
+    if (disableWifi) {
+      disableWifi.hidden = !wifiOn || wifiHard;
+      if (disableWifi.onClick && disableWifi.onClick.askForConfirm) {
+        disableWifi.onClick.askForConfirm.message = hasEth
+          ? self._t('CONFIRM.WIFI_ETH')
+          : self._t('CONFIRM.WIFI_NO_ETH');
+      }
+    }
+    if (enableWifi) {
+      enableWifi.hidden = wifiOn || wifiHard;
+    }
+    if (disableBt) {
+      disableBt.hidden = !btOn || btHard;
+    }
+    if (enableBt) {
+      enableBt.hidden = btOn || btHard;
+    }
+
+    if (enableFlight) {
+      enableFlight.hidden = flightOn || anyHard;
+      if (enableFlight.onClick && enableFlight.onClick.askForConfirm) {
+        enableFlight.onClick.askForConfirm.message = hasEth
+          ? self._t('CONFIRM.ENABLE_ETH')
+          : self._t('CONFIRM.ENABLE_NO_ETH');
+      }
+    }
+    if (disableFlight) {
+      disableFlight.hidden = !flightOn || anyHard;
+    }
+
+    if (hardNote) {
+      hardNote.hidden = !anyHard;
+      hardNote.value = self._t('HARDBLOCK.NOTE');
+    }
+
+    defer.resolve(uiconf);
+  }).fail(function (err) {
+    self.logger.error(LOG_PREFIX + 'getUIConfig failed: ' + err);
+    defer.reject(new Error());
+  });
+
+  return defer.promise;
+};
+
+ControllerFlightMode.prototype.enableFlightMode = function () {
+  return this._setRadios(false, false, 'reconcile', 'TOAST.ENABLED', true);
+};
+
+ControllerFlightMode.prototype.disableFlightMode = function () {
+  return this._setRadios(true, true, 'release', 'TOAST.DISABLED', false);
+};
+
+ControllerFlightMode.prototype.disableWifi = function () {
+  return this._setRadios(false, this._isRadioOn('bluetooth'), 'reconcile', 'TOAST.WIFI_OFF', true);
+};
+
+ControllerFlightMode.prototype.enableWifi = function () {
+  return this._setRadios(true, this._isRadioOn('bluetooth'), 'release-wifi', 'TOAST.WIFI_ON', false);
+};
+
+ControllerFlightMode.prototype.disableBluetooth = function () {
+  return this._setRadios(this._isRadioOn('wifi'), false, 'reconcile', 'TOAST.BT_OFF', true);
+};
+
+ControllerFlightMode.prototype.enableBluetooth = function () {
+  return this._setRadios(this._isRadioOn('wifi'), true, 'release-bluetooth', 'TOAST.BT_ON', false);
+};
+
+// Internals -------------------------------------------------------------------
+
+ControllerFlightMode.prototype._setRadios = function (wifiOn, bluetoothOn, mode, toastKey, checkHard) {
+  var self = this;
+  if (checkHard) {
+    var radios = self._readRadios();
+    var blocking = radios.some(function (r) {
+      if (!r.hard) {
+        return false;
+      }
+      if (mode === 'reconcile' && !wifiOn && r.type === 'wlan') {
+        return true;
+      }
+      if (mode === 'reconcile' && !bluetoothOn && r.type === 'bluetooth') {
+        return true;
+      }
+      return false;
+    });
+    if (blocking) {
+      self.commandRouter.pushToastMessage('error', self._t('PAGE.LABEL'), self._t('TOAST.HARD_DENIED'));
+      return libQ.resolve();
+    }
+  }
+
+  return self._writeRadioState(wifiOn, bluetoothOn)
+    .then(function () {
+      return self._writeMode(mode);
+    })
+    .then(function () {
+      return self._sudo('/bin/systemctl start ' + UNIT_SERVICE);
+    })
+    .then(function () {
+      self.commandRouter.pushToastMessage('success', self._t('PAGE.LABEL'), self._t(toastKey));
+      return self._refreshUI();
+    })
+    .fail(function (err) {
+      self.logger.error(LOG_PREFIX + 'setRadios failed: ' + err);
+      self.commandRouter.pushToastMessage('error', self._t('PAGE.LABEL'), self._t('TOAST.FAILED'));
+      return libQ.resolve();
+    });
+};
+
+ControllerFlightMode.prototype._pluginDir = function () {
+  return __dirname;
+};
+
+ControllerFlightMode.prototype._wifiStateFile = function () {
+  return path.join(__dirname, 'wifi.state');
+};
+
+ControllerFlightMode.prototype._bluetoothStateFile = function () {
+  return path.join(__dirname, 'bluetooth.state');
+};
+
+ControllerFlightMode.prototype._legacyStateFile = function () {
+  return path.join(__dirname, 'flightmode.state');
+};
+
+ControllerFlightMode.prototype._modeFile = function () {
+  return path.join(__dirname, 'flightmode.mode');
+};
+
+ControllerFlightMode.prototype._isRadioOn = function (which) {
+  var file = which === 'bluetooth' ? this._bluetoothStateFile() : this._wifiStateFile();
+  try {
+    if (fs.existsSync(file)) {
+      return fs.readFileSync(file, 'utf8').trim() === 'on';
+    }
+  } catch (e) {
+    this.logger.error(LOG_PREFIX + 'read ' + which + ' state failed: ' + e);
+  }
+  var key = which === 'bluetooth' ? 'bluetooth' : 'wifi';
+  if (this.config.has(key)) {
+    return !!this.config.get(key);
+  }
+  return !this.config.get('flightmode');
+};
+
+ControllerFlightMode.prototype._ensureStateFiles = function () {
+  var wifiFile = this._wifiStateFile();
+  var btFile = this._bluetoothStateFile();
+  if (!fs.existsSync(wifiFile) || !fs.existsSync(btFile)) {
+    var bothHeld = false;
+    if (fs.existsSync(this._legacyStateFile())) {
+      bothHeld = fs.readFileSync(this._legacyStateFile(), 'utf8').trim() === 'on';
+    } else if (this.config.has('flightmode')) {
+      bothHeld = !!this.config.get('flightmode');
+    }
+    var wifiOn = bothHeld ? false : (this.config.has('wifi') ? !!this.config.get('wifi') : true);
+    var btOn = bothHeld ? false : (this.config.has('bluetooth') ? !!this.config.get('bluetooth') : true);
+    this._writeRadioStateSync(wifiOn, btOn);
+  }
+  if (!fs.existsSync(this._modeFile())) {
+    fs.writeFileSync(this._modeFile(), 'reconcile\n', 'utf8');
+  }
+};
+
+ControllerFlightMode.prototype._writeRadioStateSync = function (wifiOn, bluetoothOn) {
+  this.config.set('wifi', wifiOn);
+  this.config.set('bluetooth', bluetoothOn);
+  fs.writeFileSync(this._wifiStateFile(), wifiOn ? 'on\n' : 'off\n', 'utf8');
+  fs.writeFileSync(this._bluetoothStateFile(), bluetoothOn ? 'on\n' : 'off\n', 'utf8');
+  fs.writeFileSync(this._legacyStateFile(), (!wifiOn && !bluetoothOn) ? 'on\n' : 'off\n', 'utf8');
+};
+
+ControllerFlightMode.prototype._writeRadioState = function (wifiOn, bluetoothOn) {
+  try {
+    this._writeRadioStateSync(wifiOn, bluetoothOn);
+    return libQ.resolve();
+  } catch (e) {
+    return libQ.reject(e);
+  }
+};
+
+ControllerFlightMode.prototype._writeMode = function (mode) {
+  try {
+    fs.writeFileSync(this._modeFile(), mode + '\n', 'utf8');
+    return libQ.resolve();
+  } catch (e) {
+    return libQ.reject(e);
+  }
+};
+
+ControllerFlightMode.prototype._writeServiceUnit = function () {
+  var src = path.join(__dirname, 'units', 'volumio-flightmode.service.in');
+  var dest = path.join(__dirname, 'units', UNIT_SERVICE);
+  try {
+    var text = fs.readFileSync(src, 'utf8').replace(/__PLUGIN_DIR__/g, this._pluginDir());
+    fs.writeFileSync(dest, text, 'utf8');
+    return libQ.resolve();
+  } catch (e) {
+    return libQ.reject(e);
+  }
+};
+
+ControllerFlightMode.prototype._generatePathUnit = function () {
+  var self = this;
+  var defer = libQ.defer();
+  var cmd = '/bin/bash ' + path.join(__dirname, 'scripts', 'flightmode-apply.sh') + ' --generate-path';
+  exec(cmd, { uid: 1000, gid: 1000 }, function (error, stdout, stderr) {
+    if (error) {
+      self.logger.error(LOG_PREFIX + 'generate path unit failed: ' + (stderr || error.message));
+      defer.reject(error);
+    } else {
+      defer.resolve();
+    }
+  });
+  return defer.promise;
+};
+
+ControllerFlightMode.prototype._linkUnits = function () {
+  var serviceSrc = path.join(__dirname, 'units', UNIT_SERVICE);
+  var pathSrc = path.join(__dirname, 'units', UNIT_PATH);
+  var serviceDest = path.join(SYSTEMD_DIR, UNIT_SERVICE);
+  var pathDest = path.join(SYSTEMD_DIR, UNIT_PATH);
+  var self = this;
+
+  return self._sudo('/bin/ln -sf ' + self._shellQuote(serviceSrc) + ' ' + self._shellQuote(serviceDest))
+    .then(function () {
+      return self._sudo('/bin/ln -sf ' + self._shellQuote(pathSrc) + ' ' + self._shellQuote(pathDest));
+    });
+};
+
+ControllerFlightMode.prototype._sudo = function (cmd) {
+  var self = this;
+  var defer = libQ.defer();
+  exec('/usr/bin/sudo ' + cmd, { uid: 1000, gid: 1000 }, function (error, stdout, stderr) {
+    if (error) {
+      self.logger.error(LOG_PREFIX + 'sudo failed: ' + cmd + ' :: ' + (stderr || error.message));
+      defer.reject(new Error(stderr || error.message));
+    } else {
+      defer.resolve(stdout);
+    }
+  });
+  return defer.promise;
+};
+
+ControllerFlightMode.prototype._shellQuote = function (value) {
+  return "'" + String(value).replace(/'/g, "'\\''") + "'";
+};
+
+ControllerFlightMode.prototype._readRadios = function () {
+  var radios = [];
+  if (!fs.existsSync(RFKILL_CLASS)) {
+    return radios;
+  }
+  var entries = fs.readdirSync(RFKILL_CLASS);
+  for (var i = 0; i < entries.length; i++) {
+    var dir = path.join(RFKILL_CLASS, entries[i]);
+    var typePath = path.join(dir, 'type');
+    if (!fs.existsSync(typePath)) {
+      continue;
+    }
+    var type;
+    try {
+      type = fs.readFileSync(typePath, 'utf8').trim();
+    } catch (e) {
+      continue;
+    }
+    if (type !== 'bluetooth' && type !== 'wlan') {
+      continue;
+    }
+    var name = entries[i];
+    try {
+      name = fs.readFileSync(path.join(dir, 'name'), 'utf8').trim();
+    } catch (e) {
+    }
+    var soft = false;
+    var hard = false;
+    try {
+      soft = fs.readFileSync(path.join(dir, 'soft'), 'utf8').trim() === '1';
+    } catch (e) {
+    }
+    try {
+      hard = fs.readFileSync(path.join(dir, 'hard'), 'utf8').trim() === '1';
+    } catch (e) {
+    }
+    radios.push({ id: entries[i], name: name, type: type, soft: soft, hard: hard });
+  }
+  return radios;
+};
+
+ControllerFlightMode.prototype._formatRadios = function (radios) {
+  var self = this;
+  if (!radios.length) {
+    return self._t('RADIOS.NONE');
+  }
+  return radios.map(function (r) {
+    var typeLabel = r.type === 'wlan' ? self._t('RADIOS.WLAN') : self._t('RADIOS.BLUETOOTH');
+    return self._t('RADIOS.LINE')
+      .replace('{name}', r.name)
+      .replace('{type}', typeLabel)
+      .replace('{soft}', r.soft ? self._t('SOFT.BLOCKED') : self._t('SOFT.UNBLOCKED'))
+      .replace('{hard}', r.hard ? self._t('HARD.BLOCKED') : self._t('HARD.UNBLOCKED'));
+  }).join('  |  ');
+};
+
+ControllerFlightMode.prototype._hasWiredCarrier = function () {
+  if (!fs.existsSync(NET_CLASS)) {
+    return false;
+  }
+  var ifaces = fs.readdirSync(NET_CLASS);
+  for (var i = 0; i < ifaces.length; i++) {
+    var name = ifaces[i];
+    if (name === 'lo') {
+      continue;
+    }
+    if (/^(wlan|wl|wwan|wwp|docker|br-|veth|tun|tap|virbr|cni)/.test(name)) {
+      continue;
+    }
+    if (!/^(eth|enp|ens|eno|enx|usb|en\d)/.test(name)) {
+      continue;
+    }
+    try {
+      var carrier = fs.readFileSync(path.join(NET_CLASS, name, 'carrier'), 'utf8').trim();
+      if (carrier === '1') {
+        return true;
+      }
+    } catch (e) {
+    }
+  }
+  return false;
+};
+
+ControllerFlightMode.prototype._refreshUI = function () {
+  var self = this;
+  return self.commandRouter.getUIConfigOnPlugin('system_controller', 'flightmode', {})
+    .then(function (config) {
+      self.commandRouter.broadcastMessage('pushUiConfig', config);
+    })
+    .fail(function (err) {
+      self.logger.error(LOG_PREFIX + 'refresh UI failed: ' + err);
+      return libQ.resolve();
+    });
+};
+
+ControllerFlightMode.prototype._sectionById = function (uiconf, id) {
+  if (!uiconf || !uiconf.sections) {
+    return null;
+  }
+  for (var i = 0; i < uiconf.sections.length; i++) {
+    if (uiconf.sections[i].id === id) {
+      return uiconf.sections[i];
+    }
+  }
+  return null;
+};
+
+ControllerFlightMode.prototype._contentById = function (section, id) {
+  if (!section || !section.content) {
+    return null;
+  }
+  for (var i = 0; i < section.content.length; i++) {
+    if (section.content[i].id === id) {
+      return section.content[i];
+    }
+  }
+  return null;
+};
+
+ControllerFlightMode.prototype._i18nPath = function (langCode) {
+  var candidate = path.join(__dirname, 'i18n', 'strings_' + langCode + '.json');
+  if (fs.existsSync(candidate)) {
+    return candidate;
+  }
+  return path.join(__dirname, 'i18n', 'strings_en.json');
+};
+
+ControllerFlightMode.prototype._loadStrings = function () {
+  var langCode = 'en';
+  try {
+    langCode = this.commandRouter.sharedVars.get('language_code') || 'en';
+  } catch (e) {
+  }
+  try {
+    this._strings = fs.readJsonSync(this._i18nPath(langCode));
+  } catch (e) {
+    try {
+      this._strings = fs.readJsonSync(path.join(__dirname, 'i18n', 'strings_en.json'));
+    } catch (e2) {
+      this._strings = {};
+    }
+  }
+};
+
+ControllerFlightMode.prototype._t = function (key) {
+  var parts = String(key).split('.');
+  var cur = this._strings || {};
+  for (var i = 0; i < parts.length; i++) {
+    if (cur === undefined || cur === null || !Object.prototype.hasOwnProperty.call(cur, parts[i])) {
+      return key;
+    }
+    cur = cur[parts[i]];
+  }
+  return typeof cur === 'string' ? cur : key;
+};

--- a/flightmode/install.sh
+++ b/flightmode/install.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+PLUGIN_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+echo "Installing flightmode"
+chmod 755 "${PLUGIN_DIR}/scripts/flightmode-apply.sh"
+
+echo "plugininstallend"

--- a/flightmode/package-lock.json
+++ b/flightmode/package-lock.json
@@ -1,0 +1,230 @@
+{
+  "name": "flightmode",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "flightmode",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "fs-extra": "^0.28.0",
+        "kew": "^0.7.0",
+        "v-conf": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20",
+        "volumio": ">=4"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "node_modules/fs-extra": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.28.0.tgz",
+      "integrity": "sha512-3KOJfDxp6LJn2Qj8GS7Rl8TYkX1HmPAtWawBTxPJr1uMGMtFuid5naiYD8aujiGOfufIlq69MDbigMHXHSSwkg==",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0",
+        "klaw": "^1.0.0",
+        "path-is-absolute": "^1.0.0",
+        "rimraf": "^2.2.8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/jsonfile": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/kew": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
+      "integrity": "sha512-IG6nm0+QtAMdXt9KvbgbGdvY50RSrw+U4sGZg+KlrSKPJEwVE5JVoI3d7RWfSMdBQneRheeAOj3lIjX5VL/9RQ=="
+    },
+    "node_modules/klaw": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "integrity": "sha512-TED5xi9gGQjGpNnvRWknrwAB1eL5GciPfVFOt3Vk1OJCVDQbzuSfrF3hkUQKlsgKrG1F+0t5W0m+Fje1jIt8rw==",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.9"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/multimap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/multimap/-/multimap-1.0.1.tgz",
+      "integrity": "sha512-3BA0yy/HC53U1emi32s5Kk78bwDG70Hdx4TkPFSCFTNXqsDR10VoX3zJb2Kn+L6U4X929q8WChzEy2HeI7l1Bg=="
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/v-conf": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/v-conf/-/v-conf-1.4.3.tgz",
+      "integrity": "sha512-jhnAhXDbzorq3pkoqrOzbiLP0yO4rxlfmWUvUuffDM6Dz6YZRN/LfzS1WmvJOFeq8CWapLRyO2std/U2VsOpBg==",
+      "dependencies": {
+        "fs-extra": "^3.0.1",
+        "multimap": "1.0.1",
+        "write-file-atomic": "1.3.1"
+      }
+    },
+    "node_modules/v-conf/node_modules/fs-extra": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+      "integrity": "sha512-V3Z3WZWVUYd8hoCL5xfXJCaHWYzmtwW5XWYSlLgERi8PWd8bx1kUHUk8L1BT57e49oKnDDD180mjfrHc1yA9rg==",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^3.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "node_modules/v-conf/node_modules/jsonfile": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+      "integrity": "sha512-oBko6ZHlubVB5mRFkur5vgYR1UyqX+S6Y/oCfLhqNdcc2fYFlDpIoNc7AfKS1KOGcnNAkvsr0grLck9ANM815w==",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/write-file-atomic": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.1.tgz",
+      "integrity": "sha512-RCTmbZJFENrUmJVmdaf3SiIDlP1YQGFub6P/WbrTxKHKLWmhnSgaM/cYsjxDwnzD0gVE2tlTUpX6Zr/9V4+DQg==",
+      "dependencies": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "slide": "^1.1.5"
+      }
+    }
+  }
+}

--- a/flightmode/package.json
+++ b/flightmode/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "flightmode",
+  "version": "1.0.0",
+  "description": "Soft-block WiFi and Bluetooth and keep them blocked across reboot",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Just a Nerd",
+  "license": "ISC",
+  "repository": "https://github.com/volumio/volumio-plugins-sources-bookworm",
+  "volumio_info": {
+    "prettyName": "Flight Mode",
+    "icon": "fa-plane",
+    "plugin_type": "system_controller",
+    "architectures": [
+      "amd64",
+      "armhf"
+    ],
+    "os": [
+      "bookworm"
+    ],
+    "details": "Turns WiFi and Bluetooth off with rfkill and keeps them off across reboot. No OS files are overwritten; stopping or uninstalling the plugin removes the units and releases the radios.",
+    "changelog": "1.0.0: Independent WiFi and Bluetooth toggles; flight mode is the master for both"
+  },
+  "engines": {
+    "node": ">=20",
+    "volumio": ">=4"
+  },
+  "dependencies": {
+    "fs-extra": "^0.28.0",
+    "kew": "^0.7.0",
+    "v-conf": "^1.4.0"
+  }
+}

--- a/flightmode/scripts/flightmode-apply.sh
+++ b/flightmode/scripts/flightmode-apply.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+# Apply or release per-radio rfkill policy.
+# Enumerates by type (bluetooth, wlan), never by index.
+# wifi.state / bluetooth.state: on = radio allowed, off = plugin holds a soft block.
+# Default (reconcile): soft-block each type whose state is off. Never unblock.
+# Mode release / release-wifi / release-bluetooth: soft-unblock those types, then reconcile.
+
+set -eu
+
+PLUGIN_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+WIFI_STATE_FILE="${PLUGIN_DIR}/wifi.state"
+BT_STATE_FILE="${PLUGIN_DIR}/bluetooth.state"
+MODE_FILE="${PLUGIN_DIR}/flightmode.mode"
+PATH_IN="${PLUGIN_DIR}/units/volumio-flightmode.path.in"
+PATH_GEN="${PLUGIN_DIR}/units/volumio-flightmode.path"
+RFKILL_CLASS="/sys/class/rfkill"
+
+GENERATE_ONLY=0
+if [ "${1:-}" = "--generate-path" ]; then
+  GENERATE_ONLY=1
+fi
+
+is_watched_type() {
+  case "$1" in
+    bluetooth|wlan) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+list_watched() {
+  local d t
+  if [ ! -d "${RFKILL_CLASS}" ]; then
+    return 0
+  fi
+  for d in "${RFKILL_CLASS}"/rfkill*; do
+    [ -e "${d}/type" ] || continue
+    t="$(cat "${d}/type" 2>/dev/null || true)"
+    if is_watched_type "${t}"; then
+      printf '%s\n' "${d}"
+    fi
+  done
+}
+
+device_type() {
+  cat "${1}/type" 2>/dev/null || true
+}
+
+generate_path_unit() {
+  local tmp insert d
+  if [ ! -f "${PATH_IN}" ]; then
+    echo "flightmode-apply: missing ${PATH_IN}" >&2
+    return 1
+  fi
+  tmp="${PATH_GEN}.tmp"
+  insert="PathChanged=${RFKILL_CLASS}"$'\n'
+  while IFS= read -r d; do
+    [ -n "${d}" ] || continue
+    if [ -e "${d}/soft" ]; then
+      insert="${insert}PathChanged=${d}/soft"$'\n'
+    fi
+    if [ -e "${d}/hard" ]; then
+      insert="${insert}PathChanged=${d}/hard"$'\n'
+    fi
+  done < <(list_watched)
+
+  awk -v insert="${insert}" '
+    $0 == "# FLIGHTMODE_PATHS" { printf "%s", insert; next }
+    { print }
+  ' "${PATH_IN}" > "${tmp}"
+
+  if [ -f "${PATH_GEN}" ] && cmp -s "${tmp}" "${PATH_GEN}"; then
+    rm -f "${tmp}"
+    return 1
+  fi
+  mv "${tmp}" "${PATH_GEN}"
+  return 0
+}
+
+soft_write() {
+  local d="$1"
+  local value="$2"
+  local hard soft
+  hard="$(cat "${d}/hard" 2>/dev/null || echo 1)"
+  soft="$(cat "${d}/soft" 2>/dev/null || echo "${value}")"
+  if [ "${hard}" != "0" ]; then
+    return 0
+  fi
+  if [ "${soft}" = "${value}" ]; then
+    return 0
+  fi
+  echo "${value}" > "${d}/soft" 2>/dev/null || true
+}
+
+read_trimmed() {
+  local file="$1"
+  local fallback="$2"
+  if [ -f "${file}" ]; then
+    tr -d '[:space:]' < "${file}"
+  else
+    printf '%s' "${fallback}"
+  fi
+}
+
+apply_reconcile() {
+  local d t
+  local wifi bt
+  wifi="$(read_trimmed "${WIFI_STATE_FILE}" on)"
+  bt="$(read_trimmed "${BT_STATE_FILE}" on)"
+  while IFS= read -r d; do
+    [ -n "${d}" ] || continue
+    t="$(device_type "${d}")"
+    if [ "${t}" = "wlan" ] && [ "${wifi}" = "off" ]; then
+      soft_write "${d}" 1
+    elif [ "${t}" = "bluetooth" ] && [ "${bt}" = "off" ]; then
+      soft_write "${d}" 1
+    fi
+  done < <(list_watched)
+}
+
+apply_release_type() {
+  local want="$1"
+  local d t
+  while IFS= read -r d; do
+    [ -n "${d}" ] || continue
+    t="$(device_type "${d}")"
+    if [ "${want}" = "all" ] || [ "${t}" = "${want}" ]; then
+      soft_write "${d}" 0
+    fi
+  done < <(list_watched)
+}
+
+PATH_CHANGED=0
+if generate_path_unit; then
+  PATH_CHANGED=1
+fi
+
+if [ "${GENERATE_ONLY}" -eq 1 ]; then
+  exit 0
+fi
+
+MODE="$(read_trimmed "${MODE_FILE}" reconcile)"
+
+case "${MODE}" in
+  release)
+    apply_release_type all
+    printf '%s\n' 'reconcile' > "${MODE_FILE}" || true
+    ;;
+  release-wifi)
+    apply_release_type wlan
+    printf '%s\n' 'reconcile' > "${MODE_FILE}" || true
+    ;;
+  release-bluetooth)
+    apply_release_type bluetooth
+    printf '%s\n' 'reconcile' > "${MODE_FILE}" || true
+    ;;
+  *)
+    apply_reconcile
+    ;;
+esac
+
+if [ "${PATH_CHANGED}" -eq 1 ]; then
+  /bin/systemctl daemon-reload >/dev/null 2>&1 || true
+  if /bin/systemctl is-enabled --quiet volumio-flightmode.path 2>/dev/null; then
+    /bin/systemctl restart volumio-flightmode.path >/dev/null 2>&1 || true
+  fi
+fi
+
+exit 0

--- a/flightmode/uninstall.sh
+++ b/flightmode/uninstall.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Idempotent teardown. onStop should already have done this.
+# This script runs as root via the plugin manager.
+
+PLUGIN_DIR="$(cd "$(dirname "$0")" && pwd)"
+APPLY="${PLUGIN_DIR}/scripts/flightmode-apply.sh"
+MODE_FILE="${PLUGIN_DIR}/flightmode.mode"
+
+echo "Uninstalling flightmode"
+
+printf '%s\n' 'on' > "${PLUGIN_DIR}/wifi.state" || true
+printf '%s\n' 'on' > "${PLUGIN_DIR}/bluetooth.state" || true
+printf '%s\n' 'off' > "${PLUGIN_DIR}/flightmode.state" || true
+printf '%s\n' 'release' > "${MODE_FILE}" || true
+
+if [ -x "${APPLY}" ]; then
+  "${APPLY}" || true
+fi
+
+systemctl disable --now volumio-flightmode.path >/dev/null 2>&1 || true
+systemctl disable --now volumio-flightmode.service >/dev/null 2>&1 || true
+rm -f /etc/systemd/system/volumio-flightmode.path
+rm -f /etc/systemd/system/volumio-flightmode.service
+systemctl daemon-reload >/dev/null 2>&1 || true
+
+echo "pluginuninstallend"

--- a/flightmode/units/volumio-flightmode.path.in
+++ b/flightmode/units/volumio-flightmode.path.in
@@ -1,0 +1,9 @@
+[Unit]
+Description=Re-apply Volumio flight mode after rfkill change
+After=systemd-rfkill.service
+
+[Path]
+# FLIGHTMODE_PATHS
+
+[Install]
+WantedBy=multi-user.target

--- a/flightmode/units/volumio-flightmode.service.in
+++ b/flightmode/units/volumio-flightmode.service.in
@@ -1,0 +1,13 @@
+[Unit]
+Description=Apply Volumio flight mode rfkill policy
+After=systemd-rfkill.service
+Before=wireless.service bluetooth.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash __PLUGIN_DIR__/scripts/flightmode-apply.sh
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Turns WiFi and Bluetooth off with rfkill and keeps them off across reboot. No OS files are overwritten; stopping or uninstalling the plugin removes the units and releases the radios.