### PR TITLE
replaygain - new plugin for ReplayGain volume normalization

### DIFF
--- a/replaygain/README.md
+++ b/replaygain/README.md
@@ -1,0 +1,52 @@
+# ReplayGain plugin for Volumio
+
+Plays every track at a consistent loudness, using the ReplayGain tags stored in
+your files by taggers such as [rsgain](https://github.com/complexlogic/rsgain),
+loudgain or foobar2000. Tracks without tags play unchanged.
+
+It applies to everything Volumio plays through MPD: local and NAS libraries, web
+radio, and plugins that stream to MPD such as Jellyfin. Spotify, YouTube Cast and
+AirPlay do not go through MPD and are not affected.
+
+## Settings
+
+| Setting | |
+| --- | --- |
+| **ReplayGain** | `Album gain` preserves the loudness differences between the tracks of an album. `Track gain` levels each track on its own. `Auto` uses track gain when shuffle is on and album gain otherwise. `Off` disables it. |
+| **ReplayGain preamp** | An extra −6 to +12 dB on top of ReplayGain. ReplayGain targets a fairly quiet reference level, so a positive value is often wanted. Peaks are limited, so the preamp cannot cause clipping. |
+
+Saving restarts MPD, so playback stops for a moment.
+
+## Installing
+
+From this directory, on a Volumio player:
+
+```bash
+volumio plugin install
+```
+
+For a different player, run `volumio plugin package` and upload the resulting zip
+to `http://<player>:3000/plugin-upload`.
+
+## Where the settings go
+
+The plugin registers with the MPD plugin's `registerConfigCallback()`, which
+appends its settings to `/etc/mpd.conf` every time Volumio regenerates it:
+
+```
+### ReplayGain (managed by the replaygain plugin)
+replaygain                      "album"
+replaygain_preamp               "0"
+replaygain_missing_preamp       "0"
+replaygain_limit                "yes"
+```
+
+Nothing under `/volumio` is modified, so the settings survive Volumio updates.
+
+## Good to know
+
+- Uninstalling restarts Volumio about twenty seconds after it finishes, to clear
+  the callback the plugin registered with MPD. This is expected; let it run.
+- If you previously added `replaygain` lines to `mpd.conf.tmpl` over SSH, remove
+  them. The plugin manages those settings itself, and MPD will not start when a
+  setting is defined twice.

--- a/replaygain/UIConfig.json
+++ b/replaygain/UIConfig.json
@@ -1,0 +1,144 @@
+{
+  "page": {
+    "label": "TRANSLATE.PAGE_TITLE"
+  },
+  "sections": [
+    {
+      "id": "replaygain_settings",
+      "element": "section",
+      "label": "TRANSLATE.SECTION_TITLE",
+      "icon": "fa-sliders",
+      "description": "TRANSLATE.SECTION_DESC",
+      "onSave": {
+        "type": "controller",
+        "endpoint": "audio_interface/replaygain",
+        "method": "saveSettings"
+      },
+      "saveButton": {
+        "label": "TRANSLATE.SAVE",
+        "data": [
+          "mode",
+          "preamp"
+        ]
+      },
+      "content": [
+        {
+          "id": "mode",
+          "element": "select",
+          "label": "TRANSLATE.MODE",
+          "doc": "TRANSLATE.MODE_DESC",
+          "value": {
+            "value": "album",
+            "label": "TRANSLATE.MODE_ALBUM"
+          },
+          "options": [
+            {
+              "value": "off",
+              "label": "TRANSLATE.MODE_OFF"
+            },
+            {
+              "value": "album",
+              "label": "TRANSLATE.MODE_ALBUM"
+            },
+            {
+              "value": "track",
+              "label": "TRANSLATE.MODE_TRACK"
+            },
+            {
+              "value": "auto",
+              "label": "TRANSLATE.MODE_AUTO"
+            }
+          ]
+        },
+        {
+          "id": "preamp",
+          "element": "select",
+          "label": "TRANSLATE.PREAMP",
+          "doc": "TRANSLATE.PREAMP_DESC",
+          "value": {
+            "value": 0,
+            "label": "0 dB"
+          },
+          "options": [
+            {
+              "value": -6,
+              "label": "-6 dB"
+            },
+            {
+              "value": -5,
+              "label": "-5 dB"
+            },
+            {
+              "value": -4,
+              "label": "-4 dB"
+            },
+            {
+              "value": -3,
+              "label": "-3 dB"
+            },
+            {
+              "value": -2,
+              "label": "-2 dB"
+            },
+            {
+              "value": -1,
+              "label": "-1 dB"
+            },
+            {
+              "value": 0,
+              "label": "0 dB"
+            },
+            {
+              "value": 1,
+              "label": "+1 dB"
+            },
+            {
+              "value": 2,
+              "label": "+2 dB"
+            },
+            {
+              "value": 3,
+              "label": "+3 dB"
+            },
+            {
+              "value": 4,
+              "label": "+4 dB"
+            },
+            {
+              "value": 5,
+              "label": "+5 dB"
+            },
+            {
+              "value": 6,
+              "label": "+6 dB"
+            },
+            {
+              "value": 7,
+              "label": "+7 dB"
+            },
+            {
+              "value": 8,
+              "label": "+8 dB"
+            },
+            {
+              "value": 9,
+              "label": "+9 dB"
+            },
+            {
+              "value": 10,
+              "label": "+10 dB"
+            },
+            {
+              "value": 11,
+              "label": "+11 dB"
+            },
+            {
+              "value": 12,
+              "label": "+12 dB"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/replaygain/config.json
+++ b/replaygain/config.json
@@ -1,0 +1,10 @@
+{
+  "mode": {
+    "type": "string",
+    "value": "album"
+  },
+  "preamp": {
+    "type": "number",
+    "value": 0
+  }
+}

--- a/replaygain/i18n/strings_en.json
+++ b/replaygain/i18n/strings_en.json
@@ -1,0 +1,14 @@
+{
+  "PAGE_TITLE": "ReplayGain",
+  "SECTION_TITLE": "ReplayGain",
+  "SECTION_DESC": "Plays every track at a consistent loudness using the ReplayGain tags already stored in your files, as written by taggers such as rsgain, loudgain or foobar2000. Tracks without tags are left untouched. Saving restarts the player.",
+  "SAVE": "Save",
+  "MODE": "ReplayGain",
+  "MODE_DESC": "Album mode keeps the loudness differences within an album intact, which is what you want when listening to albums end to end. Track mode levels every track on its own.",
+  "MODE_OFF": "Off",
+  "MODE_ALBUM": "Album gain",
+  "MODE_TRACK": "Track gain",
+  "MODE_AUTO": "Auto (track gain when shuffling)",
+  "PREAMP": "ReplayGain preamp",
+  "PREAMP_DESC": "Gain applied on top of ReplayGain. ReplayGain targets a fairly quiet reference level, so a positive preamp is often desirable. Clipping is prevented automatically."
+}

--- a/replaygain/index.js
+++ b/replaygain/index.js
@@ -1,0 +1,322 @@
+'use strict';
+
+var libQ = require('kew');
+var fs = require('fs');
+var os = require('os');
+
+var MPD_TEMPLATE = '/volumio/app/plugins/music_service/mpd/mpd.conf.tmpl';
+var MPD_CONF = '/etc/mpd.conf';
+var BLOCK_MARKER = '### ReplayGain (managed by the replaygain plugin)';
+var VALID_MODES = ['off', 'track', 'album', 'auto'];
+
+module.exports = ControllerReplayGain;
+
+function ControllerReplayGain (context) {
+  var self = this;
+
+  self.context = context;
+  self.commandRouter = self.context.coreCommand;
+  self.logger = self.commandRouter.logger;
+  self.configManager = self.context.configManager;
+
+  // registerConfigCallback() has no unregister counterpart: register once only,
+  // and keep answering after onStop() with an empty string.
+  self.callbackRegistered = false;
+  self.active = false;
+}
+
+ControllerReplayGain.prototype.onVolumioStart = function () {
+  var self = this;
+  var configFile = self.commandRouter.pluginManager.getConfigurationFile(self.context, 'config.json');
+
+  self.config = new (require('v-conf'))();
+  self.config.loadFile(configFile);
+
+  return libQ.resolve();
+};
+
+ControllerReplayGain.prototype.getConfigurationFiles = function () {
+  return ['config.json'];
+};
+
+ControllerReplayGain.prototype.onStart = function () {
+  var self = this;
+
+  self.active = true;
+  self.registerMpdCallback();
+
+  // A failed MPD restart should not block startup; saving from the settings
+  // page retries.
+  return self.applyToMpd().fail(function () {
+    return libQ.resolve();
+  });
+};
+
+ControllerReplayGain.prototype.onStop = function () {
+  var self = this;
+
+  // The callback stays registered but now contributes nothing.
+  self.active = false;
+
+  return self.applyToMpd().fail(function () {
+    return libQ.resolve();
+  });
+};
+
+ControllerReplayGain.prototype.onRestart = function () {
+  var self = this;
+
+  self.active = true;
+
+  return self.applyToMpd().fail(function () {
+    return libQ.resolve();
+  });
+};
+
+ControllerReplayGain.prototype.registerMpdCallback = function () {
+  var self = this;
+
+  if (self.callbackRegistered) {
+    return;
+  }
+
+  self.commandRouter.executeOnPlugin('music_service', 'mpd', 'registerConfigCallback', {
+    type: 'audio_interface',
+    plugin: 'replaygain',
+    data: 'getMpdConfig'
+  });
+  self.callbackRegistered = true;
+};
+
+/**
+ * Called by createMPDFile(), which concatenates the return value straight into
+ * mpd.conf. Must always return a string: anything else lands in the file as
+ * "undefined" and MPD then refuses to start.
+ */
+ControllerReplayGain.prototype.getMpdConfig = function () {
+  var self = this;
+
+  try {
+    if (!self.active) {
+      return '';
+    }
+
+    if (self.templateSetsReplayGain()) {
+      self.logger.error('replaygain: ' + MPD_TEMPLATE + ' already sets replaygain itself. ' +
+        'Contributing nothing, as a duplicate setting would stop MPD from starting.');
+      return '';
+    }
+
+    return self.buildMpdConfig();
+  } catch (e) {
+    self.logger.error('replaygain: could not build mpd.conf settings: ' + e);
+    return '';
+  }
+};
+
+ControllerReplayGain.prototype.buildMpdConfig = function () {
+  var self = this;
+  var mode = self.getMode();
+
+  if (mode === 'off') {
+    return '';
+  }
+
+  return os.EOL + BLOCK_MARKER + os.EOL +
+    'replaygain\t\t\t"' + mode + '"' + os.EOL +
+    'replaygain_preamp\t\t"' + self.getPreamp() + '"' + os.EOL +
+    // Untagged tracks are left alone rather than boosted from an unnormalized level.
+    'replaygain_missing_preamp\t"0"' + os.EOL +
+    // Uses the peak tags to keep a positive preamp from clipping.
+    'replaygain_limit\t\t"yes"' + os.EOL;
+};
+
+/**
+ * A hand-edited template may set replaygain itself. Contributing on top of that
+ * would define the setting twice, which MPD rejects.
+ */
+ControllerReplayGain.prototype.templateSetsReplayGain = function () {
+  var self = this;
+
+  try {
+    var template = fs.readFileSync(MPD_TEMPLATE, 'utf8');
+
+    return template.split(/\r?\n/).some(function (line) {
+      return /^\s*replaygain\s/.test(line);
+    });
+  } catch (e) {
+    self.logger.error('replaygain: could not read ' + MPD_TEMPLATE + ': ' + e);
+    return false;
+  }
+};
+
+ControllerReplayGain.prototype.getMode = function () {
+  var self = this;
+  var mode = self.config.get('mode', 'off');
+
+  if (VALID_MODES.indexOf(mode) === -1) {
+    self.logger.error('replaygain: invalid mode "' + mode + '", falling back to off');
+    return 'off';
+  }
+
+  return mode;
+};
+
+ControllerReplayGain.prototype.getPreamp = function () {
+  var self = this;
+  var preamp = parseInt(self.config.get('preamp', 0), 10);
+
+  if (isNaN(preamp) || preamp < -15 || preamp > 15) {
+    self.logger.error('replaygain: invalid preamp "' + self.config.get('preamp') + '", falling back to 0');
+    return 0;
+  }
+
+  return preamp;
+};
+
+/**
+ * Skips the work when mpd.conf already matches, so an unchanged config does not
+ * cost an MPD restart on every boot.
+ */
+ControllerReplayGain.prototype.applyToMpd = function () {
+  var self = this;
+  var defer = libQ.defer();
+
+  if (self.isAlreadyApplied()) {
+    self.logger.info('replaygain: mpd.conf is already up to date, not restarting MPD');
+    defer.resolve();
+    return defer.promise;
+  }
+
+  self.commandRouter.executeOnPlugin('music_service', 'mpd', 'createMPDFile', function (error) {
+    if (error) {
+      self.logger.error('replaygain: could not create mpd.conf: ' + error);
+      defer.reject(error);
+      return;
+    }
+
+    // createMPDFile() calls back before its own async writeFile() has landed,
+    // so restarting straight away can race with it and pick up the old file.
+    self.waitForConfig(function () {
+      self.commandRouter.executeOnPlugin('music_service', 'mpd', 'restartMpd', function (error) {
+        if (error) {
+          self.logger.error('replaygain: could not restart MPD: ' + error);
+          defer.reject(error);
+        } else {
+          self.logger.info('replaygain: applied "' + self.getMode() + '" mode, preamp ' + self.getPreamp() + ' dB');
+          defer.resolve();
+        }
+      });
+    });
+  });
+
+  return defer.promise;
+};
+
+ControllerReplayGain.prototype.isAlreadyApplied = function () {
+  var self = this;
+  var desired = self.getMpdConfig();
+
+  try {
+    var current = fs.readFileSync(MPD_CONF, 'utf8');
+
+    if (desired === '') {
+      // Substring-matching an empty string always succeeds, which would leave
+      // stale settings behind when ReplayGain is switched off.
+      return current.indexOf(BLOCK_MARKER) === -1;
+    }
+
+    return current.indexOf(desired) !== -1;
+  } catch (e) {
+    return false;
+  }
+};
+
+ControllerReplayGain.prototype.waitForConfig = function (callback) {
+  var self = this;
+  var attempts = 0;
+
+  var poll = function () {
+    if (self.isAlreadyApplied() || attempts >= 30) {
+      if (attempts >= 30) {
+        self.logger.error('replaygain: timed out waiting for mpd.conf to be written, restarting MPD anyway');
+      }
+      callback();
+      return;
+    }
+
+    attempts++;
+    setTimeout(poll, 100);
+  };
+
+  poll();
+};
+
+ControllerReplayGain.prototype.getUIConfig = function () {
+  var self = this;
+  var defer = libQ.defer();
+  var langCode = self.commandRouter.sharedVars.get('language_code');
+
+  self.commandRouter.i18nJson(__dirname + '/i18n/strings_' + langCode + '.json',
+    __dirname + '/i18n/strings_en.json',
+    __dirname + '/UIConfig.json')
+    .then(function (uiconf) {
+      var mode = self.getMode();
+      var preamp = self.getPreamp();
+
+      uiconf.sections[0].content[0].value.value = mode;
+      uiconf.sections[0].content[0].value.label = self.getLabelForSelect(uiconf.sections[0].content[0].options, mode);
+      uiconf.sections[0].content[1].value.value = preamp;
+      uiconf.sections[0].content[1].value.label = self.getLabelForSelect(uiconf.sections[0].content[1].options, preamp);
+
+      defer.resolve(uiconf);
+    })
+    .fail(function (error) {
+      self.logger.error('replaygain: could not build the settings page: ' + error);
+      defer.reject(new Error());
+    });
+
+  return defer.promise;
+};
+
+ControllerReplayGain.prototype.getLabelForSelect = function (options, key) {
+  for (var i = 0; i < options.length; i++) {
+    if (options[i].value == key) {
+      return options[i].label;
+    }
+  }
+
+  return String(key);
+};
+
+ControllerReplayGain.prototype.saveSettings = function (data) {
+  var self = this;
+  var defer = libQ.defer();
+
+  self.config.set('mode', data['mode'].value);
+  self.config.set('preamp', data['preamp'].value);
+
+  self.applyToMpd()
+    .then(function () {
+      self.commandRouter.pushToastMessage('success',
+        self.commandRouter.getI18nString('COMMON.CONFIGURATION_UPDATE'),
+        self.commandRouter.getI18nString('COMMON.SETTINGS_SAVED_SUCCESSFULLY'));
+      defer.resolve({});
+    })
+    .fail(function () {
+      self.commandRouter.pushToastMessage('error',
+        self.commandRouter.getI18nString('COMMON.CONFIGURATION_UPDATE'),
+        self.commandRouter.getI18nString('COMMON.SETTINGS_SAVE_ERROR'));
+      defer.resolve({});
+    });
+
+  return defer.promise;
+};
+
+ControllerReplayGain.prototype.getConfigParam = function (key) {
+  return this.config.get(key);
+};
+
+ControllerReplayGain.prototype.setConfigParam = function (data) {
+  this.config.set(data.key, data.value);
+};

--- a/replaygain/install.sh
+++ b/replaygain/install.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "Installing ReplayGain plugin"
+
+# Nothing to install: Volumio's MPD already provides ReplayGain support.
+
+echo "plugininstallend"

--- a/replaygain/package.json
+++ b/replaygain/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "replaygain",
+  "version": "1.0.0",
+  "description": "ReplayGain volume normalization for Volumio",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Claudio Saavedra",
+  "license": "MIT",
+  "volumio_info": {
+    "prettyName": "ReplayGain",
+    "plugin_type": "audio_interface",
+    "os": [
+      "bookworm"
+    ],
+    "icon": "fa-sliders",
+    "boot_priority": 10,
+    "details": "Plays every track at a consistent loudness using the ReplayGain tags already stored in your files, as written by rsgain, loudgain, foobar2000 or similar taggers. Applies to everything that plays through MPD, including local and NAS libraries, web radio and plugins such as Jellyfin.",
+    "changelog": "bookworm version",
+    "architectures": [
+      "amd64",
+      "armhf"
+    ]
+  },
+  "engines": {
+    "volumio": ">=4",
+    "node": ">=20"
+  },
+  "dependencies": {
+    "kew": "^0.7.0",
+    "v-conf": "^1.4.2"
+  },
+  "repository": "https://github.com/volumio/volumio-plugins-sources-bookworm"
+}

--- a/replaygain/uninstall.sh
+++ b/replaygain/uninstall.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+echo "Uninstalling ReplayGain plugin"
+
+# registerConfigCallback() has no unregister counterpart, so the callback
+# outlives the uninstall; once Volumio drops the plugin instance it resolves to
+# undefined and mpd.conf gets the literal string. Restarting the backend clears
+# it. The delay matters: this script runs midway through the uninstall sequence,
+# and restarting straight away would kill the backend before the plugin is fully
+# removed. The redirect keeps the subshell off the pipe Volumio waits on.
+echo "Volumio will restart in a few seconds to complete the uninstall"
+( sleep 20; /bin/systemctl restart volumio.service ) >/dev/null 2>&1 &
+
+echo "Done"
+echo "pluginuninstallend"


### PR DESCRIPTION
Plays every track at a consistent loudness from the ReplayGain tags already present in the user's files, for everything that goes through MPD. Settings are mode (off/track/album/auto) and preamp (-6..+12 dB). replaygain_missing_preamp is pinned to 0 so untagged tracks play unchanged, and replaygain_limit to yes so the preamp cannot clip.

MPD is built with ReplayGain support but nothing enables it, and the existing Volume normalization switch is a different feature that ignores tags.

The settings reach /etc/mpd.conf through the MPD plugin's registerConfigCallback() rather than by editing mpd.conf.tmpl, so they are re-applied on every regeneration and no file under /volumio is touched.

Three details in the implementation are deliberate:

  * getMpdConfig() always returns a string. createMPDFile() concatenates the return value with no guard and executeOnPlugin() answers undefined for an unloaded plugin, which would otherwise write the literal string undefined into mpd.conf and stop MPD from starting.

  * uninstall.sh delays its backend restart. The restart is needed because registerConfigCallback() has no unregister counterpart, but the script runs midway through the uninstall sequence, so restarting immediately would kill the backend before the plugin is removed from the configuration and its folder deleted.

  * The plugin contributes nothing when mpd.conf.tmpl already sets replaygain, since MPD rejects a redefined setting, and MPD is only restarted when /etc/mpd.conf does not already match the current settings.